### PR TITLE
Email api will not require from & subject if template id is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `collect` helper changed to `Collection` class
+- `from` and `subject` are not mandatory if `template_id` is set
 
 ### Removed
 
@@ -24,3 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Helpers for recipients, variables & attachments
 - PHPUnit tests
 - Documentation
+
+[Unreleased]: https://github.com/mailerlite/mailersend/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/mailerlite/mailersend/releases/tag/v0.1.0

--- a/src/Endpoints/Email.php
+++ b/src/Endpoints/Email.php
@@ -21,14 +21,19 @@ class Email extends AbstractEndpoint
      */
     public function send(EmailParams $params): array
     {
-        GeneralHelpers::assert(fn() => Assertion::email($params->getFrom()) &&
-            Assertion::minLength($params->getFromName(), 1) &&
-            Assertion::minCount($params->getRecipients(), 1) &&
-            Assertion::minLength($params->getSubject(), 1) &&
-            Assertion::notEmpty(array_filter([$params->getTemplateId(), $params->getHtml(), $params->getText()],
-                fn($v) => $v !== null),
-                'One of template_id, html or text must be supplied')
-        );
+        GeneralHelpers::assert(fn() => Assertion::notEmpty(array_filter([
+            $params->getTemplateId(), $params->getHtml(), $params->getText()
+        ], fn($v) => $v !== null), 'One of template_id, html or text must be supplied'));
+
+        if (!$params->getTemplateId()) {
+            GeneralHelpers::assert(fn() => Assertion::email($params->getFrom()) &&
+                Assertion::minLength($params->getFromName(), 1) &&
+                Assertion::minLength($params->getSubject(), 1) &&
+                Assertion::minCount($params->getRecipients(), 1)
+            );
+        } else {
+            GeneralHelpers::assert(fn() => Assertion::minCount($params->getRecipients(), 1));
+        }
 
         $recipients_mapped = (new Collection($params->getRecipients()))->map(fn($v) => is_object($v) && is_a($v,
             Recipient::class) ? $v->toArray() : $v)->toArray();


### PR DESCRIPTION
This is based on changes coming from the upstream API updates