### PR TITLE
array_filter already filters out null values

### DIFF
--- a/src/Endpoints/Email.php
+++ b/src/Endpoints/Email.php
@@ -61,7 +61,7 @@ class Email extends AbstractEndpoint
                 'tags' => $params->getTags(),
                 'attachments' => $attachments_mapped,
                 'variables' => $variables_mapped
-            ], fn($v) => is_array($v) ? array_filter($v, fn($v) => $v !== null) : $v !== null
+            ], fn($v) => is_array($v) ? array_filter($v) : $v !== null
             ));
     }
 }


### PR DESCRIPTION
Although it uses `empty()` which filters out empty strings too.

>  If no callback is supplied, all empty entries of array will be removed. See empty() for how PHP defines empty in this case. 

https://www.php.net/manual/en/function.array-filter.php