### PR TITLE
Add build status badge

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 MailerSend PHP SDK
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)
+![build badge](https://github.com/mailersend/mailersend-php/actions/workflows/php.yml/badge.svg)
+
 
 # Table of Contents
 


### PR DESCRIPTION
This PR adds a status badge to display the SDK's build status.

### Why are we doing this?
Status badges help providing some KPIs or metrics about the repository.

### Testing Procedure
 - Navigate to the repository's github page.
 - There should be a badge indicating if the build is passing/failing.
