### PR TITLE
Add code quality tools

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,43 @@
+name: Code style and static analysis
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+jobs:
+    run:
+
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                operating-system: [ubuntu-latest]
+                php-versions: ['7.4','8.0']
+        name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  extensions: mbstring, pdo, pdo_mysql, intl, zip
+                  coverage: none
+
+            - name: Cache Composer packages
+              id: composer-cache
+              uses: actions/cache@v2
+              with:
+                  path: vendor
+                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-php-
+
+            - name: Install dependencies
+              if: steps.composer-cache.outputs.cache-hit != 'true'
+              run: composer install --prefer-dist --no-progress --no-suggest
+
+            - name: Run PHP-CS-Fixer
+              run: composer run-script phpcs

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,4 +40,4 @@ jobs:
               run: composer install --prefer-dist --no-progress --no-suggest
 
             - name: Run PHP-CS-Fixer
-              run: composer run-script phpcs
+              run: composer run-script phpcs --  --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ composer.phar
 composer.lock
 /vendor/
 .idea
+.php_cs.cache
 .phpunit.result.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,8 +1,7 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-;
+    ->in(__DIR__);
 
 $config = new PhpCsFixer\Config();
 return $config->setRules([

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -5,6 +5,6 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 return $config->setRules([
-
+    '@PSR12' => true,
 ])
     ->setFinder($finder);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,11 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+;
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+
+])
+    ->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 MailerSend PHP SDK
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)
+![build badge](https://github.com/mailersend/mailersend-php/actions/workflows/static-analysis.yml/badge.svg)
+
+
 
 # Table of Contents
 

--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,8 @@
     "test": [
       "@php vendor/bin/phpunit tests/"
     ],
-      "phpcs": [
-          "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run"
-      ]
+    "phpcs": [
+        "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "MailerSend PHP SDK",
   "type": "library",
   "license": "MIT",
-  "homepage": "https://github.com/mailersend/laravel-driver-driver",
+  "homepage": "https://github.com/mailersend/mailersend-php",
   "keywords": [
     "MailerSend",
     "mailersend",
@@ -36,7 +36,8 @@
     "mockery/mockery": "^0.9.4",
     "guzzlehttp/psr7": "^1.5.2",
     "http-interop/http-factory-guzzle": "^1.0",
-    "php-http/guzzle7-adapter": "^0.1"
+    "php-http/guzzle7-adapter": "^0.1",
+    "friendsofphp/php-cs-fixer": "^2.18"
   },
   "autoload": {
     "psr-4": {
@@ -51,6 +52,9 @@
   "scripts": {
     "test": [
       "@php vendor/bin/phpunit tests/"
-    ]
+    ],
+      "phpcs": [
+          "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run"
+      ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
       "@php vendor/bin/phpunit tests/"
     ],
     "phpcs": [
-        "vendor/bin/php-cs-fixer fix --verbose --diff"
+      "@php vendor/bin/php-cs-fixer fix --verbose --diff"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
       "@php vendor/bin/phpunit tests/"
     ],
     "phpcs": [
-        "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run"
+        "vendor/bin/php-cs-fixer fix --verbose --diff"
     ]
   }
 }


### PR DESCRIPTION
### Summary

This PR adds [php-cs fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) as a static code analyser to verify that new commits adhere to the project's coding standards and find potential bugs.

<!-- Provide the issue no related to this PR -->
Fixes #2 

### Testing Procedure

1. Open a Pull request or add new commits to the main branch
2. A github action for code quality should be executed, and the status badge updated depending on the result
3. If there are any errors, try running `composer phpcs` and the errors should be fixed.

### Pending tasks
- [ ] Add rules to  [php_cs.dist](https://github.com/osvaldoM/mailersend-php/blob/006e4560620506202caf1b369cda6f6cc5991f3c/.php_cs.dist). At the moment this is only checking for compliance with PSR-12


### Preview
![image](https://user-images.githubusercontent.com/11247633/116105550-b7eb3780-a6b1-11eb-9cf1-6dd27a84cf00.png)
