### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: 🐞 Bug report
+about: Report a reproducible bug or regression in mailersend php SDK.
+
+---
+
+<!-- Requirements: please go through this checklist before opening a new issue -->
+
+- [ ] Review the documentation: https://developers.mailersend.com/#mailersend-api
+- [ ] Search for existing issues
+- [ ] Use the latest release: https://github.com/mailersend/mailersend-php/releases
+
+### Summary
+
+<!-- Provide a brief summary of the issue -->
+
+
+### Expected Results
+
+<!-- Tell us what should happen -->
+
+
+### Actual Results
+
+<!-- Tell us what happens instead -->
+
+
+### Steps to Reproduce
+
+<!--
+Provide a link to a live example, or an unambiguous set of steps to reproduce
+this bug include code to reproduce, if relevant
+-->
+
+1.
+2.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for improving the mailersend php SDK.
+
+---
+
+### Is your proposal related to a problem?
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when..."
+-->
+
+(Write your answer here.)
+
+### Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+(Describe your proposed solution here.)
+
+### Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+(Write your answer here.)
+
+### Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->
+
+(Write your answer here.)


### PR DESCRIPTION
While searching for things that I could fix in the repo, I noticed that many issues did not have a description, which made it difficult to understand what the author of the issue really wanted.

This PR adds templates to guide authors when creating clearly described issues.