### PR TITLE
Token Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `GET`, `PUT` and `DELETE` methods to `HttpLayer` class
+- Token create, update, delete endpoints.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ composer require mailersend/mailersend
 <a name="usage"></a>
 # Usage
 
-Sending a basic email.
+### Sending a basic email.
 
 ```php
 use MailerSend\MailerSend;
@@ -64,14 +64,62 @@ $emailParams = (new EmailParams())
 $mailersend->email->send($emailParams);
 ```
 
+### Managing Tokens
+
+**Create a new token**
+
+```php
+use MailerSend\MailerSend;
+use MailerSend\Helpers\Builder\TokenParams;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
+$mailersend->token->create(
+    new TokenParams('token name', 'domainId', TokenParams::ALL_SCOPES)
+);
+```
+
+Because of security reasons, we only allow access token appearance once during creation. In order to see the access token created you can do:
+
+```php
+use MailerSend\Helpers\Builder\TokenParams;
+
+$response = $mailersend->token->create(
+    new TokenParams('token name', 'domainId', TokenParams::ALL_SCOPES)
+);
+
+echo $response['body']['data']['accessToken'];
+```
+
+**Pause / Unpause Token**
+
+```php
+use MailerSend\Helpers\Builder\TokenParams;
+
+$mailersend->token->update('token_id', TokenParams::STATUS_PAUSE); // PAUSE
+$mailersend->token->update('token_id', TokenParams::STATUS_UNPAUSE); // UNPAUSE
+```
+
+**Delete Token**
+
+```php
+use MailerSend\Helpers\Builder\TokenParams;
+
+$mailersend->token->delete('token_id');
+```
+
+
 For more expanded usage info, see [guide](GUIDE.md).
 
 <a name="endpoints"></a>
 # Available endpoints
 
-| Feature group | Endpoint    | Available |
-| ------------- | ----------- | --------- |
-| Email         | `POST send` | ✅         |
+| Feature group     | Endpoint                          | Available |
+| -------------     | -----------                       | --------- |
+| Email             | `POST send`                       | ✅        |
+| Token : Create    | `POST token`                      | ✅        |
+| Token : Update    | `PUT token/{token_id}/settings`   | ✅        |
+| Token : Delete    | `DELETE token/{token_id}`         | ✅        |
 
 *If, at the moment, some endpoint is not available, please use `cURL` and other available tools to access it. [Refer to official API docs for more info](https://developers.mailersend.com/).*
 

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -91,36 +91,6 @@ class HttpLayer
     }
 
     /**
-     * @param string $uri
-     * @param array $body
-     * @return array
-     * @throws ClientExceptionInterface
-     * @throws JsonException
-     */
-    public function put(string $uri, array $body): array
-    {
-        $request = $this->requestFactory->createRequest('PUT', $uri)
-            ->withBody($this->buildBody($body));
-
-        return $this->buildResponse($this->pluginClient->sendRequest($request));
-    }
-
-    /**
-     * @param string $uri
-     * @param array $body
-     * @return array
-     * @throws ClientExceptionInterface
-     * @throws JsonException
-     */
-    public function delete(string $uri, array $body): array
-    {
-        $request = $this->requestFactory->createRequest('DELETE', $uri)
-            ->withBody($this->buildBody($body));
-
-        return $this->buildResponse($this->pluginClient->sendRequest($request));
-    }
-
-    /**
      * @throws JsonException
      * @throws ClientExceptionInterface
      */

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -91,6 +91,36 @@ class HttpLayer
     }
 
     /**
+     * @param string $uri
+     * @param array $body
+     * @return array
+     * @throws ClientExceptionInterface
+     * @throws JsonException
+     */
+    public function put(string $uri, array $body): array
+    {
+        $request = $this->requestFactory->createRequest('PUT', $uri)
+            ->withBody($this->buildBody($body));
+
+        return $this->buildResponse($this->pluginClient->sendRequest($request));
+    }
+
+    /**
+     * @param string $uri
+     * @param array $body
+     * @return array
+     * @throws ClientExceptionInterface
+     * @throws JsonException
+     */
+    public function delete(string $uri, array $body): array
+    {
+        $request = $this->requestFactory->createRequest('DELETE', $uri)
+            ->withBody($this->buildBody($body));
+
+        return $this->buildResponse($this->pluginClient->sendRequest($request));
+    }
+
+    /**
      * @throws JsonException
      * @throws ClientExceptionInterface
      */

--- a/src/Endpoints/Token.php
+++ b/src/Endpoints/Token.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace MailerSend\Endpoints;
-
 
 use Assert\Assertion;
 use JsonException;
@@ -26,7 +24,7 @@ class Token extends AbstractEndpoint
     public function create(TokenParams $tokenParams): array
     {
         GeneralHelpers::assert(
-            fn () => Assertion::minLength($tokenParams->getName(), 1,  'Token name is required.') &&
+            fn () => Assertion::minLength($tokenParams->getName(), 1, 'Token name is required.') &&
                 Assertion::minLength($tokenParams->getDomainId(), 1, 'Token domain id is required.') &&
                 Assertion::minCount($tokenParams->getScopes(), 1, 'Token scopes are required.')
         );

--- a/src/Endpoints/Token.php
+++ b/src/Endpoints/Token.php
@@ -1,0 +1,89 @@
+<?php
+
+
+namespace MailerSend\Endpoints;
+
+
+use Assert\Assertion;
+use JsonException;
+use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\Builder\TokenParams;
+use MailerSend\Helpers\GeneralHelpers;
+use Psr\Http\Client\ClientExceptionInterface;
+
+class Token extends AbstractEndpoint
+{
+    protected string $endpoint = 'token';
+
+
+    /**
+     * @param TokenParams $tokenParams
+     * @return array
+     * @throws JsonException
+     * @throws MailerSendAssertException
+     * @throws ClientExceptionInterface
+     */
+    public function create(TokenParams $tokenParams): array
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::minLength($tokenParams->getName(), 1,  'Token name is required.') &&
+                Assertion::minLength($tokenParams->getDomainId(), 1, 'Token domain id is required.') &&
+                Assertion::minCount($tokenParams->getScopes(), 1, 'Token scopes are required.')
+        );
+
+        return $this->httpLayer->post(
+            $this->buildUri($this->endpoint),
+            array_filter(
+                [
+                    'name' => $tokenParams->getName(),
+                    'domain_id' => $tokenParams->getDomainId(),
+                    'scopes' => $tokenParams->getScopes(),
+                ],
+            ),
+        );
+    }
+
+    /**
+     * @param string $id
+     * @param string $status
+     * @return array
+     * @throws ClientExceptionInterface
+     * @throws JsonException
+     * @throws MailerSendAssertException
+     */
+    public function update(string $id, string $status): array
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::notEmpty($id, 'Token id is required.') &&
+                Assertion::inArray($status, TokenParams::STATUS_ALL)
+        );
+
+        return $this->httpLayer->put(
+            $this->buildUri($this->endpoint . '/' . $id . '/settings'),
+            array_filter(
+                [
+                    'status' => $status,
+                ],
+            ),
+        );
+    }
+
+    /**
+     * @param string $id
+     * @return array
+     * @throws ClientExceptionInterface
+     * @throws JsonException
+     * @throws MailerSendAssertException
+     */
+    public function delete(string $id): array
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::notEmpty($id, 'Token id is required.')
+        );
+
+        return $this->httpLayer->delete(
+            $this->buildUri($this->endpoint . '/' . $id),
+            []
+        );
+    }
+}

--- a/src/Helpers/Builder/TokenParams.php
+++ b/src/Helpers/Builder/TokenParams.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace MailerSend\Helpers\Builder;
-
 
 use Assert\Assertion;
 use JsonSerializable;
@@ -12,7 +10,9 @@ use Tightenco\Collect\Contracts\Support\Arrayable;
 
 class TokenParams implements Arrayable, JsonSerializable
 {
-    private string $name, $domainId, $token;
+    private string $name;
+    private string $domainId;
+    private string $token;
     private array $scopes;
 
     public const EMAIL_FULL = 'email_full';

--- a/src/Helpers/Builder/TokenParams.php
+++ b/src/Helpers/Builder/TokenParams.php
@@ -12,7 +12,6 @@ class TokenParams implements Arrayable, JsonSerializable
 {
     private string $name;
     private string $domainId;
-    private string $token;
     private array $scopes;
 
     public const EMAIL_FULL = 'email_full';

--- a/src/Helpers/Builder/TokenParams.php
+++ b/src/Helpers/Builder/TokenParams.php
@@ -1,0 +1,136 @@
+<?php
+
+
+namespace MailerSend\Helpers\Builder;
+
+
+use Assert\Assertion;
+use JsonSerializable;
+use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\GeneralHelpers;
+use Tightenco\Collect\Contracts\Support\Arrayable;
+
+class TokenParams implements Arrayable, JsonSerializable
+{
+    private string $name, $domainId, $token;
+    private array $scopes;
+
+    public const EMAIL_FULL = 'email_full';
+    public const DOMAINS_READ = 'domains_read';
+    public const DOMAINS_FULL = 'domains_full';
+    public const ACTIVITY_READ = 'activity_read';
+    public const ACTIVITY_FULL = 'activity_full';
+    public const ANALYTICS_READ = 'analytics_read';
+    public const ANALYTICS_FULL = 'analytics_full';
+    public const TOKENS_FULL = 'tokens_full';
+    public const WEBHOOKS_FULL = 'webhooks_full';
+    public const TEMPLATES_FULL = 'templates_full';
+
+    public const ALL_SCOPES = [
+        self::EMAIL_FULL,
+        self::DOMAINS_READ, self::DOMAINS_FULL,
+        self::ACTIVITY_READ, self::ACTIVITY_FULL,
+        self::ANALYTICS_READ, self::ANALYTICS_FULL,
+        self::TOKENS_FULL,
+        self::WEBHOOKS_FULL,
+        self::TEMPLATES_FULL,
+    ];
+
+    public const STATUS_PAUSE = 'pause';
+    public const STATUS_UNPAUSE = 'unpause';
+    public const STATUS_ALL = [ self::STATUS_PAUSE, self::STATUS_UNPAUSE ];
+
+
+    /**
+     * TokenParams constructor.
+     * @param string $name
+     * @param string $domainId
+     * @param array $scopes
+     * @throws MailerSendAssertException
+     */
+    public function __construct(string $name, string $domainId, array $scopes)
+    {
+        $this->setName($name)
+            ->setDomainId($domainId)
+            ->setScopes($scopes);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return TokenParams
+     */
+    public function setName(string $name): TokenParams
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDomainId(): string
+    {
+        return $this->domainId;
+    }
+
+    /**
+     * @param string $domainId
+     * @return TokenParams
+     */
+    public function setDomainId(string $domainId): TokenParams
+    {
+        $this->domainId = $domainId;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+
+    /**
+     * @param array $scopes
+     * @return TokenParams
+     * @throws MailerSendAssertException
+     */
+    public function setScopes(array $scopes): TokenParams
+    {
+        GeneralHelpers::assert(
+            fn () =>  Assertion::allInArray($scopes, self::ALL_SCOPES, 'Some scopes are not valid.')
+        );
+
+        $this->scopes = $scopes;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->getName(),
+            'domain_id' => $this->getDomainId(),
+            'scopes' => $this->getScopes(),
+        ]);
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/MailerSend.php
+++ b/src/MailerSend.php
@@ -4,6 +4,7 @@ namespace MailerSend;
 
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Email;
+use MailerSend\Endpoints\Token;
 use MailerSend\Exceptions\MailerSendException;
 use Tightenco\Collect\Support\Arr;
 
@@ -27,6 +28,7 @@ class MailerSend
     protected ?HttpLayer $httpLayer;
 
     public Email $email;
+    public Token $token;
 
     /**
      * @param  array  $options  Additional options for the SDK
@@ -43,6 +45,7 @@ class MailerSend
     protected function setEndpoints(): void
     {
         $this->email = new Email($this->httpLayer, $this->options);
+        $this->token = new Token($this->httpLayer, $this->options);
     }
 
     protected function setHttpLayer(?HttpLayer $httpLayer = null): void

--- a/tests/Endpoints/TokenTest.php
+++ b/tests/Endpoints/TokenTest.php
@@ -1,0 +1,148 @@
+<?php
+
+
+namespace MailerSend\Tests\Endpoints;
+
+
+use Http\Mock\Client;
+use MailerSend\Common\HttpLayer;
+use MailerSend\Endpoints\Token;
+use MailerSend\Helpers\Builder\TokenParams;
+use MailerSend\Tests\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Tightenco\Collect\Support\Arr;
+
+class TokenTest extends TestCase
+{
+    protected Token $token;
+    protected ResponseInterface $defaultResponse;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = new Client();
+
+        $this->token = new Token(new HttpLayer(self::OPTIONS, $this->client), self::OPTIONS);
+        $this->defaultResponse = $this->createMock(ResponseInterface::class);
+        $this->defaultResponse->method('getStatusCode')->willReturn(200);
+    }
+
+    public function test_create_token_with_empty_name_throws_errors(): void
+    {
+        $this->expectExceptionMessage('Token name is required.');
+
+        $this->token->create(
+            new TokenParams('', 'token_domain', TokenParams::ALL_SCOPES)
+        );
+    }
+
+    public function test_create_token_with_empty_domainId_throws_errors(): void
+    {
+        $this->expectExceptionMessage('Token domain id is required.');
+
+        $this->token->create(
+            new TokenParams('token name', '', TokenParams::ALL_SCOPES)
+        );
+    }
+
+    public function test_create_token_with_empty_scopes_throws_errors(): void
+    {
+        $this->expectExceptionMessage('Token scopes are required.');
+
+        $this->token->create(
+            new TokenParams('token name', 'domainId', [])
+        );
+    }
+
+    public function test_create_token_with_invalid_scope_throws_errors(): void
+    {
+        $this->expectExceptionMessage('Some scopes are not valid.');
+
+        $this->token->create(
+            new TokenParams('', '', [ 'invalid_scope' ])
+        );
+    }
+
+    public function test_create_token()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->token->create(
+            $this->validTokenParams()
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals('/v1/token', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame($this->validTokenParams()->getName(), Arr::get($request_body, 'name'));
+        self::assertSame($this->validTokenParams()->getDomainId(), Arr::get($request_body, 'domain_id'));
+        self::assertSame($this->validTokenParams()->getScopes(), Arr::get($request_body, 'scopes'));
+    }
+
+    public function test_pause_token()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->token->update(
+            'random_id', TokenParams::STATUS_PAUSE
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('PUT', $request->getMethod());
+        self::assertEquals('/v1/token/random_id/settings', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame(TokenParams::STATUS_PAUSE, Arr::get($request_body, 'status'));
+    }
+
+    public function test_unpause_token()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->token->update(
+            'random_id', TokenParams::STATUS_UNPAUSE
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('PUT', $request->getMethod());
+        self::assertEquals('/v1/token/random_id/settings', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame(TokenParams::STATUS_UNPAUSE, Arr::get($request_body, 'status'));
+    }
+
+    public function test_delete_token()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->token->delete('random_id');
+
+        $request = $this->client->getLastRequest();
+
+        self::assertEquals('DELETE', $request->getMethod());
+        self::assertEquals('/v1/token/random_id', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+    }
+
+    private function validTokenParams(): TokenParams
+    {
+        return new TokenParams('name', 'domainId', TokenParams::ALL_SCOPES);
+    }
+}

--- a/tests/Endpoints/TokenTest.php
+++ b/tests/Endpoints/TokenTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace MailerSend\Tests\Endpoints;
-
 
 use Http\Mock\Client;
 use MailerSend\Common\HttpLayer;
@@ -93,7 +91,8 @@ class TokenTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->token->update(
-            'random_id', TokenParams::STATUS_PAUSE
+            'random_id',
+            TokenParams::STATUS_PAUSE
         );
 
         $request = $this->client->getLastRequest();
@@ -113,7 +112,8 @@ class TokenTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->token->update(
-            'random_id', TokenParams::STATUS_UNPAUSE
+            'random_id',
+            TokenParams::STATUS_UNPAUSE
         );
 
         $request = $this->client->getLastRequest();


### PR DESCRIPTION
Changelist

- [x] Add support for `PUT` & `DELETE` to the `HttpLayer`.
- [x] `Token` create endpoint.
- [x] `Token` update endpoint.
- [x] `Token` delete endpoint.
- [x] Documentation update

Breaking changes:
- N/A

