### PR TITLE
Messages endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `GET`, `PUT` and `DELETE` methods to `HttpLayer` class
+- Messages API, listing resources, and showing a specific one.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,20 @@ $mailersend->email->send($emailParams);
 **List messages**
 
 ```php
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
 $mailersend->messages->get($limit = 100, $page = 3);
 ```
 
 **Find a specific message**
 
 ```php
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
 $mailersend->messages->find('message_id');
 ```
 
@@ -87,7 +95,7 @@ For more expanded usage info, see [guide](GUIDE.md).
 | -------------         | -----------                   | --------- |
 | Email                 | `POST send`                   | ✅        |
 | Messages : list       | `GET messages`                | ✅        |
-| Messages : find       | `GET messages/{token_id}`     | ✅        |
+| Messages : find       | `GET messages/{message_id}`     | ✅        |
 
 *If, at the moment, some endpoint is not available, please use `cURL` and other available tools to access it. [Refer to official API docs for more info](https://developers.mailersend.com/).*
 

--- a/README.md
+++ b/README.md
@@ -64,14 +64,30 @@ $emailParams = (new EmailParams())
 $mailersend->email->send($emailParams);
 ```
 
+### Messages
+
+**List messages**
+
+```php
+$mailersend->messages->get($limit = 100, $page = 3);
+```
+
+**Find a specific message**
+
+```php
+$mailersend->messages->find('message_id');
+```
+
 For more expanded usage info, see [guide](GUIDE.md).
 
 <a name="endpoints"></a>
 # Available endpoints
 
-| Feature group | Endpoint    | Available |
-| ------------- | ----------- | --------- |
-| Email         | `POST send` | ✅         |
+| Feature group         | Endpoint                      | Available |
+| -------------         | -----------                   | --------- |
+| Email                 | `POST send`                   | ✅        |
+| Messages : list       | `GET messages`                | ✅        |
+| Messages : find       | `GET messages/{token_id}`     | ✅        |
 
 *If, at the moment, some endpoint is not available, please use `cURL` and other available tools to access it. [Refer to official API docs for more info](https://developers.mailersend.com/).*
 

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -94,6 +94,18 @@ class HttpLayer
      * @throws JsonException
      * @throws ClientExceptionInterface
      */
+    public function get(string $uri, array $body): array
+    {
+        $request = $this->requestFactory->createRequest('GET', $uri)
+            ->withBody($this->buildBody($body));
+
+        return $this->buildResponse($this->pluginClient->sendRequest($request));
+    }
+
+    /**
+     * @throws JsonException
+     * @throws ClientExceptionInterface
+     */
     public function request(string $method, string $uri, string $body = ''): array
     {
         $request = $this->requestFactory->createRequest($method, $uri);

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -94,18 +94,6 @@ class HttpLayer
      * @throws JsonException
      * @throws ClientExceptionInterface
      */
-    public function get(string $uri, array $body): array
-    {
-        $request = $this->requestFactory->createRequest('GET', $uri)
-            ->withBody($this->buildBody($body));
-
-        return $this->buildResponse($this->pluginClient->sendRequest($request));
-    }
-
-    /**
-     * @throws JsonException
-     * @throws ClientExceptionInterface
-     */
     public function request(string $method, string $uri, string $body = ''): array
     {
         $request = $this->requestFactory->createRequest($method, $uri);

--- a/src/Endpoints/Message.php
+++ b/src/Endpoints/Message.php
@@ -43,12 +43,12 @@ class Message extends AbstractEndpoint
 
 
     /**
-     * @param int $id
+     * @param string $id
      * @return array
      * @throws \JsonException
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function find(int $id): array
+    public function find(string $id): array
     {
         return $this->httpLayer->get(
             $this->buildUri($this->endpoint . '/' . $id),

--- a/src/Endpoints/Message.php
+++ b/src/Endpoints/Message.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MailerSend\Endpoints;
+
+use Assert\Assertion;
+use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\GeneralHelpers;
+
+class Message extends AbstractEndpoint
+{
+    protected string $endpoint = 'messages';
+
+    public const DEFAULT_LIMIT = 25;
+    public const MAX_LIMIT = 100;
+    public const MIN_LIMIT = 10;
+
+
+    /**
+     * @param int|null $limit
+     * @param int|null $page
+     * @return array
+     * @throws MailerSendAssertException
+     * @throws \JsonException
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     */
+    public function get(?int $limit = self::DEFAULT_LIMIT, ?int $page = null): array
+    {
+        if ($limit) {
+            GeneralHelpers::assert(
+                fn () => Assertion::min($limit, self::MIN_LIMIT, 'Minimum limit is ' . self::MIN_LIMIT . '.') &&
+                    Assertion::max($limit, self::MAX_LIMIT, 'Maximum limit is ' . self::MAX_LIMIT . '.')
+            );
+        }
+
+        return $this->httpLayer->get(
+            $this->buildUri($this->endpoint),
+            array_filter([
+                'limit' => $limit,
+                'page' => $page
+            ])
+        );
+    }
+
+
+    /**
+     * @param int $id
+     * @return array
+     * @throws \JsonException
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     */
+    public function find(int $id): array
+    {
+        return $this->httpLayer->get(
+            $this->buildUri($this->endpoint . '/' . $id),
+            []
+        );
+    }
+}

--- a/src/Endpoints/Message.php
+++ b/src/Endpoints/Message.php
@@ -50,9 +50,6 @@ class Message extends AbstractEndpoint
      */
     public function find(string $id): array
     {
-        return $this->httpLayer->get(
-            $this->buildUri($this->endpoint . '/' . $id),
-            []
-        );
+        return $this->httpLayer->get($this->buildUri($this->endpoint . '/' . $id));
     }
 }

--- a/src/MailerSend.php
+++ b/src/MailerSend.php
@@ -4,6 +4,7 @@ namespace MailerSend;
 
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Email;
+use MailerSend\Endpoints\Message;
 use MailerSend\Exceptions\MailerSendException;
 use Tightenco\Collect\Support\Arr;
 
@@ -27,6 +28,7 @@ class MailerSend
     protected ?HttpLayer $httpLayer;
 
     public Email $email;
+    public Message $messages;
 
     /**
      * @param  array  $options  Additional options for the SDK
@@ -43,6 +45,7 @@ class MailerSend
     protected function setEndpoints(): void
     {
         $this->email = new Email($this->httpLayer, $this->options);
+        $this->messages = new Message($this->httpLayer, $this->options);
     }
 
     protected function setHttpLayer(?HttpLayer $httpLayer = null): void

--- a/tests/Endpoints/MessageTest.php
+++ b/tests/Endpoints/MessageTest.php
@@ -57,4 +57,19 @@ class MessageTest extends TestCase
         self::assertSame(30, Arr::get($request_body, 'limit'));
         self::assertSame(2, Arr::get($request_body, 'page'));
     }
+
+    public function test_find_message()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->messages->find('random_id');
+
+        $request = $this->client->getLastRequest();
+
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals('/v1/messages/random_id', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+    }
 }

--- a/tests/Endpoints/MessageTest.php
+++ b/tests/Endpoints/MessageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MailerSend\Tests\Endpoints;
+
+use Http\Mock\Client;
+use MailerSend\Common\HttpLayer;
+use MailerSend\Endpoints\Message;
+use MailerSend\Tests\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Tightenco\Collect\Support\Arr;
+
+class MessageTest extends TestCase
+{
+    protected Message $messages;
+    protected ResponseInterface $defaultResponse;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = new Client();
+
+        $this->messages = new Message(new HttpLayer(self::OPTIONS, $this->client), self::OPTIONS);
+        $this->defaultResponse = $this->createMock(ResponseInterface::class);
+        $this->defaultResponse->method('getStatusCode')->willReturn(200);
+    }
+
+    public function test_get_messages_min_limit_is_validated()
+    {
+        $this->expectExceptionMessage('Minimum limit is ' . Message::MIN_LIMIT . '.');
+
+        $this->messages->get(9);
+    }
+
+    public function test_get_messages_max_limit_is_validated()
+    {
+        $this->expectExceptionMessage('Maximum limit is ' . Message::MAX_LIMIT . '.');
+
+        $this->messages->get(101);
+    }
+
+    public function test_get_messages_rand_limit_is_validated()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->messages->get(30, 2);
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals('/v1/messages', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame(30, Arr::get($request_body, 'limit'));
+        self::assertSame(2, Arr::get($request_body, 'page'));
+    }
+}

--- a/tests/Endpoints/MessageTest.php
+++ b/tests/Endpoints/MessageTest.php
@@ -39,7 +39,7 @@ class MessageTest extends TestCase
         $this->messages->get(101);
     }
 
-    public function test_get_messages_rand_limit_is_validated()
+    public function test_get_messages()
     {
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);


### PR DESCRIPTION
Changelist

- [x] Add support for `GET` to the `HttpLayer`.
- [x] `Messages` listing endpoint.
- [x] `Messages` find endpoint for listing the details of a specific message.
- [x] Documentation update

Breaking changes:
- N/A

