### PR TITLE
Webhooks endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `GET`, `PUT` and `DELETE` methods to `HttpLayer` class
+- Webhook, get, find, create, update, and delete endpoints.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,19 @@ $mailersend->email->send($emailParams);
 
 **List Webhooks**
 ```php
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
 $mailersend->webhooks->get('domain_id');
 ```
 
 **Find a Webhook**
 ```php
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
 $mailersend->webhooks->find('webhook_id');
 ```
 
@@ -80,6 +88,9 @@ $mailersend->webhooks->find('webhook_id');
 
 ```php
 use MailerSend\Helpers\Builder\WebhookParams;
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
 
 $mailersend->webhooks->create(
     new WebhookParams('https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id')
@@ -90,6 +101,9 @@ $mailersend->webhooks->create(
 
 ```php
 use MailerSend\Helpers\Builder\WebhookParams;
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
 
 $mailersend->webhooks->create(
     new WebhookParams('https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id', false)
@@ -100,6 +114,9 @@ $mailersend->webhooks->create(
 
 ```php
 use MailerSend\Helpers\Builder\WebhookParams;
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
 
 $mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES);
 ```
@@ -108,6 +125,9 @@ $mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name
 
 ```php
 use MailerSend\Helpers\Builder\WebhookParams;
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
 
 $mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, true); //Enabled
 $mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, false); //Disabled
@@ -116,6 +136,10 @@ $mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name
 **Delete a Webhook**
 
 ```php
+use MailerSend\MailerSend;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
 $mailersend->webhooks->delete('webhook_id');
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,14 +64,75 @@ $emailParams = (new EmailParams())
 $mailersend->email->send($emailParams);
 ```
 
+### Webhooks endpoint
+
+**List Webhooks**
+```php
+$mailersend->webhooks->get('domain_id');
+```
+
+**Find a Webhook**
+```php
+$mailersend->webhooks->find('webhook_id');
+```
+
+**Create a Webhook**
+
+```php
+use MailerSend\Helpers\Builder\WebhookParams;
+
+$mailersend->webhooks->create(
+    new WebhookParams('https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id')
+);
+```
+
+**Create a disabled Webhook**
+
+```php
+use MailerSend\Helpers\Builder\WebhookParams;
+
+$mailersend->webhooks->create(
+    new WebhookParams('https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id', false)
+);
+```
+
+**Update a Webhook**
+
+```php
+use MailerSend\Helpers\Builder\WebhookParams;
+
+$mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES);
+```
+
+**Disable/Enable a Webhook**
+
+```php
+use MailerSend\Helpers\Builder\WebhookParams;
+
+$mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, true); //Enabled
+$mailersend->webhooks->update('webhook_id', 'https://webhook_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, false); //Disabled
+```
+
+**Delete a Webhook**
+
+```php
+$mailersend->webhooks->delete('webhook_id');
+```
+
+
 For more expanded usage info, see [guide](GUIDE.md).
 
 <a name="endpoints"></a>
 # Available endpoints
 
-| Feature group | Endpoint    | Available |
-| ------------- | ----------- | --------- |
-| Email         | `POST send` | ✅         |
+| Feature group             | Endpoint                      | Available  |
+| -------------             | -----------                   | ---------  |
+| Email                     | `POST send`                   | ✅         |
+| Webhook : list            | `GET webhooks`                | ✅         |
+| Webhook : find            | `GET webhooks/{webhook_id}`   | ✅         |
+| Webhook : create          | `POST webhooks`               | ✅         |
+| Webhook : update          | `PUT webhooks/{webhook_id}`   | ✅         |
+| Webhook : delete          | `DELETE webhooks/{webhook_id}`| ✅         |
 
 *If, at the moment, some endpoint is not available, please use `cURL` and other available tools to access it. [Refer to official API docs for more info](https://developers.mailersend.com/).*
 

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -94,42 +94,6 @@ class HttpLayer
      * @throws JsonException
      * @throws ClientExceptionInterface
      */
-    public function put(string $uri, array $body): array
-    {
-        $request = $this->requestFactory->createRequest('PUT', $uri)
-            ->withBody($this->buildBody($body));
-
-        return $this->buildResponse($this->pluginClient->sendRequest($request));
-    }
-
-    /**
-     * @throws JsonException
-     * @throws ClientExceptionInterface
-     */
-    public function get(string $uri, array $body): array
-    {
-        $request = $this->requestFactory->createRequest('GET', $uri)
-            ->withBody($this->buildBody($body));
-
-        return $this->buildResponse($this->pluginClient->sendRequest($request));
-    }
-
-    /**
-     * @throws JsonException
-     * @throws ClientExceptionInterface
-     */
-    public function delete(string $uri, array $body): array
-    {
-        $request = $this->requestFactory->createRequest('DELETE', $uri)
-            ->withBody($this->buildBody($body));
-
-        return $this->buildResponse($this->pluginClient->sendRequest($request));
-    }
-
-    /**
-     * @throws JsonException
-     * @throws ClientExceptionInterface
-     */
     public function request(string $method, string $uri, string $body = ''): array
     {
         $request = $this->requestFactory->createRequest($method, $uri);

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -94,6 +94,30 @@ class HttpLayer
      * @throws JsonException
      * @throws ClientExceptionInterface
      */
+    public function get(string $uri, array $body): array
+    {
+        $request = $this->requestFactory->createRequest('GET', $uri)
+            ->withBody($this->buildBody($body));
+
+        return $this->buildResponse($this->pluginClient->sendRequest($request));
+    }
+
+    /**
+     * @throws JsonException
+     * @throws ClientExceptionInterface
+     */
+    public function delete(string $uri, array $body): array
+    {
+        $request = $this->requestFactory->createRequest('DELETE', $uri)
+            ->withBody($this->buildBody($body));
+
+        return $this->buildResponse($this->pluginClient->sendRequest($request));
+    }
+
+    /**
+     * @throws JsonException
+     * @throws ClientExceptionInterface
+     */
     public function request(string $method, string $uri, string $body = ''): array
     {
         $request = $this->requestFactory->createRequest($method, $uri);

--- a/src/Common/HttpLayer.php
+++ b/src/Common/HttpLayer.php
@@ -94,6 +94,18 @@ class HttpLayer
      * @throws JsonException
      * @throws ClientExceptionInterface
      */
+    public function put(string $uri, array $body): array
+    {
+        $request = $this->requestFactory->createRequest('PUT', $uri)
+            ->withBody($this->buildBody($body));
+
+        return $this->buildResponse($this->pluginClient->sendRequest($request));
+    }
+
+    /**
+     * @throws JsonException
+     * @throws ClientExceptionInterface
+     */
     public function get(string $uri, array $body): array
     {
         $request = $this->requestFactory->createRequest('GET', $uri)

--- a/src/Endpoints/Webhook.php
+++ b/src/Endpoints/Webhook.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace MailerSend\Endpoints;
+
+use Assert\Assertion;
+use MailerSend\Helpers\Builder\WebhookParams;
+use MailerSend\Helpers\GeneralHelpers;
+
+class Webhook extends AbstractEndpoint
+{
+    protected string $endpoint = 'webhooks';
+
+    /**
+     * @param string $domainId
+     * @return array
+     * @throws \MailerSend\Exceptions\MailerSendAssertException
+     */
+    public function get(string $domainId): array
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::minLength($domainId, 1, 'Domain id is required.')
+        );
+
+        return $this->httpLayer->get(
+            $this->buildUri($this->endpoint),
+            array_filter([
+                'domain_id' => $domainId
+            ])
+        );
+    }
+
+
+    /**
+     * @param string $id
+     * @return array
+     * @throws \JsonException
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \MailerSend\Exceptions\MailerSendAssertException
+     */
+    public function find(string $id): array
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::minLength($id, 1, 'Webhook id is required.')
+        );
+
+        return $this->httpLayer->get(
+            $this->buildUri($this->endpoint . '/' . $id),
+            []
+        );
+    }
+
+
+    /**
+     * @param string $id
+     * @return array
+     * @throws \JsonException
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \MailerSend\Exceptions\MailerSendAssertException
+     */
+    public function delete(string $id): array
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::minLength($id, 1, 'Webhook id is required.')
+        );
+
+        return $this->httpLayer->delete(
+            $this->buildUri($this->endpoint . '/' . $id),
+            []
+        );
+    }
+}

--- a/src/Endpoints/Webhook.php
+++ b/src/Endpoints/Webhook.php
@@ -102,10 +102,7 @@ class Webhook extends AbstractEndpoint
             fn () => Assertion::minLength($id, 1, 'Webhook id is required.')
         );
 
-        return $this->httpLayer->get(
-            $this->buildUri($this->endpoint . '/' . $id),
-            []
-        );
+        return $this->httpLayer->get($this->buildUri($this->endpoint . '/' . $id));
     }
 
 
@@ -122,9 +119,6 @@ class Webhook extends AbstractEndpoint
             fn () => Assertion::minLength($id, 1, 'Webhook id is required.')
         );
 
-        return $this->httpLayer->delete(
-            $this->buildUri($this->endpoint . '/' . $id),
-            []
-        );
+        return $this->httpLayer->delete($this->buildUri($this->endpoint . '/' . $id));
     }
 }

--- a/src/Helpers/Builder/WebhookParams.php
+++ b/src/Helpers/Builder/WebhookParams.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace MailerSend\Helpers\Builder;
-
 
 use Assert\Assertion;
 use MailerSend\Exceptions\MailerSendAssertException;

--- a/src/Helpers/Builder/WebhookParams.php
+++ b/src/Helpers/Builder/WebhookParams.php
@@ -1,0 +1,165 @@
+<?php
+
+
+namespace MailerSend\Helpers\Builder;
+
+
+use Assert\Assertion;
+use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\GeneralHelpers;
+use Tightenco\Collect\Contracts\Support\Arrayable;
+
+class WebhookParams implements Arrayable, \JsonSerializable
+{
+    private string $url;
+    private string $name;
+    private array $events;
+    private ?bool $enabled;
+    private string $domainId;
+
+    public const ACTIVITY_SENT = 'activity.sent';
+    public const ACTIVITY_DELIVERED = 'activity.delivered';
+    public const ACTIVITY_SOFT_BOUNCED = 'activity.soft_bounced';
+    public const ACTIVITY_HARD_BOUNCED = 'activity.hard_bounced';
+    public const ACTIVITY_OPENED = 'activity.opened';
+    public const ACTIVITY_CLICKED = 'activity.clicked';
+    public const ACTIVITY_UNSUBSCRIBED = 'activity.unsubscribed';
+    public const ACTIVITY_SPAM_COMPLAINT = 'activity.spam_complaint';
+
+    public const ALL_ACTIVITIES = [
+        self::ACTIVITY_SENT, self::ACTIVITY_DELIVERED,
+        self::ACTIVITY_SOFT_BOUNCED, self::ACTIVITY_HARD_BOUNCED,
+        self::ACTIVITY_OPENED, self::ACTIVITY_CLICKED,
+        self::ACTIVITY_UNSUBSCRIBED, self::ACTIVITY_SPAM_COMPLAINT,
+    ];
+
+    /**
+     * WebhookParams constructor.
+     * @param string $url
+     * @param string $name
+     * @param array $events
+     * @param string $domainId
+     * @param bool|null $enabled
+     * @throws MailerSendAssertException
+     */
+    public function __construct(string $url, string $name, array $events, string $domainId, ?bool $enabled = null)
+    {
+        $this->setUrl($url)
+            ->setName($name)
+            ->setEvents($events)
+            ->setEnabled($enabled)
+            ->setDomainId($domainId);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     * @return WebhookParams
+     */
+    public function setUrl(string $url): WebhookParams
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return WebhookParams
+     */
+    public function setName(string $name): WebhookParams
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
+
+    /**
+     * @param array $events
+     * @return $this
+     * @throws MailerSendAssertException
+     */
+    public function setEvents(array $events): WebhookParams
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::allInArray($events, self::ALL_ACTIVITIES, 'One or multiple invalid events.')
+        );
+
+        $this->events = $events;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEnabled(): ?string
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool|null $enabled
+     * @return WebhookParams
+     */
+    public function setEnabled(?bool $enabled): WebhookParams
+    {
+        $this->enabled = $enabled;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDomainId(): string
+    {
+        return $this->domainId;
+    }
+
+    /**
+     * @param string $domainId
+     * @return WebhookParams
+     */
+    public function setDomainId(string $domainId): WebhookParams
+    {
+        $this->domainId = $domainId;
+        return $this;
+    }
+
+
+    public function toArray()
+    {
+        return [
+            'url' => $this->getUrl(),
+            'name' => $this->getName(),
+            'events' => $this->getEvents(),
+            'enabled' => $this->getEnabled(),
+            'domain_id' => $this->getDomainId(),
+        ];
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/MailerSend.php
+++ b/src/MailerSend.php
@@ -4,6 +4,7 @@ namespace MailerSend;
 
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Email;
+use MailerSend\Endpoints\Webhook;
 use MailerSend\Exceptions\MailerSendException;
 use Tightenco\Collect\Support\Arr;
 
@@ -27,6 +28,7 @@ class MailerSend
     protected ?HttpLayer $httpLayer;
 
     public Email $email;
+    public Webhook $webhooks;
 
     /**
      * @param  array  $options  Additional options for the SDK
@@ -43,6 +45,7 @@ class MailerSend
     protected function setEndpoints(): void
     {
         $this->email = new Email($this->httpLayer, $this->options);
+        $this->webhooks = new Webhook($this->httpLayer, $this->options);
     }
 
     protected function setHttpLayer(?HttpLayer $httpLayer = null): void

--- a/tests/Endpoints/WebhookTest.php
+++ b/tests/Endpoints/WebhookTest.php
@@ -295,7 +295,7 @@ class WebhookTest extends TestCase
         $response->method('getStatusCode')->willReturn(200);
         $this->client->addResponse($response);
 
-        $response = $this->webhooks->update('random_id', 'https://link.com/webhook', 'Webhook name', [WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], true);
+        $response = $this->webhooks->update('random_id', 'https://link.com/webhook', 'Webhook name', [WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], false);
 
         $request = $this->client->getLastRequest();
         $request_body = json_decode((string) $request->getBody(), true);
@@ -307,6 +307,6 @@ class WebhookTest extends TestCase
         self::assertSame('https://link.com/webhook', Arr::get($request_body, 'url'));
         self::assertSame('Webhook name', Arr::get($request_body, 'name'));
         self::assertSame([WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], Arr::get($request_body, 'events'));
-        self::assertEquals(true, Arr::get($request_body, 'enabled'));
+        self::assertEquals(false, Arr::get($request_body, 'enabled'));
     }
 }

--- a/tests/Endpoints/WebhookTest.php
+++ b/tests/Endpoints/WebhookTest.php
@@ -5,6 +5,7 @@ namespace MailerSend\Tests\Endpoints;
 use Http\Mock\Client;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Webhook;
+use MailerSend\Helpers\Builder\WebhookParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Tightenco\Collect\Support\Arr;
@@ -92,5 +93,220 @@ class WebhookTest extends TestCase
         self::assertEquals('DELETE', $request->getMethod());
         self::assertEquals('/v1/webhooks/webhook_id', $request->getUri()->getPath());
         self::assertEquals(200, $response['status_code']);
+    }
+
+    public function test_url_is_validated_when_creating_webhooks()
+    {
+        $this->expectExceptionMessage('Invalid URL.');
+
+        $this->webhooks->create(
+            new WebhookParams('invalid_url', 'Webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id')
+        );
+    }
+
+    public function test_name_is_required_when_creating_webhooks()
+    {
+        $this->expectExceptionMessage('Webhook name is required.');
+
+        $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', '', WebhookParams::ALL_ACTIVITIES, 'domain_id')
+        );
+    }
+
+    public function test_events_are_required_when_creating_webhooks()
+    {
+        $this->expectExceptionMessage('Webhook events are required.');
+
+        $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', [], 'domain_id')
+        );
+    }
+
+    public function test_events_are_validated_when_creating_webhooks()
+    {
+        $this->expectExceptionMessage('One or multiple invalid events.');
+
+        $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', ['invalid event'], 'domain_id')
+        );
+    }
+
+    public function test_domain_id_is_required_when_creating_webhooks()
+    {
+        $this->expectExceptionMessage('Webhook domain id is required.');
+
+        $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', WebhookParams::ALL_ACTIVITIES, '')
+        );
+    }
+
+    public function test_create_webhooks()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id')
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals('/v1/webhooks', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame('https://link.com/webhook', Arr::get($request_body, 'url'));
+        self::assertSame('webhook name', Arr::get($request_body, 'name'));
+        self::assertSame(WebhookParams::ALL_ACTIVITIES, Arr::get($request_body, 'events'));
+        self::assertSame('domain_id', Arr::get($request_body, 'domain_id'));
+        self::assertNull(Arr::get($request_body, 'enabled'));
+    }
+
+    public function test_create_disabled_webhooks()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id', false)
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals('/v1/webhooks', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame('https://link.com/webhook', Arr::get($request_body, 'url'));
+        self::assertSame('webhook name', Arr::get($request_body, 'name'));
+        self::assertSame(WebhookParams::ALL_ACTIVITIES, Arr::get($request_body, 'events'));
+        self::assertSame('domain_id', Arr::get($request_body, 'domain_id'));
+        self::assertEquals(false, Arr::get($request_body, 'enabled'));
+    }
+
+    public function test_create_enabled_webhooks()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', WebhookParams::ALL_ACTIVITIES, 'domain_id', true)
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals('/v1/webhooks', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame('https://link.com/webhook', Arr::get($request_body, 'url'));
+        self::assertSame('webhook name', Arr::get($request_body, 'name'));
+        self::assertSame(WebhookParams::ALL_ACTIVITIES, Arr::get($request_body, 'events'));
+        self::assertSame('domain_id', Arr::get($request_body, 'domain_id'));
+        self::assertEquals(true, Arr::get($request_body, 'enabled'));
+    }
+
+    public function test_update_webhook_requires_id()
+    {
+        $this->expectExceptionMessage('Webhook id is required.');
+
+        $this->webhooks->update('', 'https://link.com/webhook', 'Webhook name', WebhookParams::ALL_ACTIVITIES);
+    }
+
+    public function test_update_webhook_requires_url()
+    {
+        $this->expectExceptionMessage('Invalid URL.');
+
+        $this->webhooks->update('random_id', '', 'Webhook name', WebhookParams::ALL_ACTIVITIES);
+    }
+
+    public function test_update_webhook_requires_name()
+    {
+        $this->expectExceptionMessage('Webhook name is required.');
+
+        $this->webhooks->update('random_id', 'https://link.com/webhook', '', WebhookParams::ALL_ACTIVITIES);
+    }
+
+    public function test_update_webhook_requires_events()
+    {
+        $this->expectExceptionMessage('Webhook events are required.');
+
+        $this->webhooks->update('random_id', 'https://link.com/webhook', 'Webhook name', []);
+    }
+
+    public function test_update_webhook_events_are_validated()
+    {
+        $this->expectExceptionMessage('One or multiple invalid events.');
+
+        $this->webhooks->update('random_id', 'https://link.com/webhook', 'Webhook name', ['invalid_activity_1', 'invalid_activity_2']);
+    }
+
+    public function test_update_webhooks()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->update('random_id', 'https://link.com/webhook', 'Webhook name', [WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED]);
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('PUT', $request->getMethod());
+        self::assertEquals('/v1/webhooks/random_id', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame('https://link.com/webhook', Arr::get($request_body, 'url'));
+        self::assertSame('Webhook name', Arr::get($request_body, 'name'));
+        self::assertSame([WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], Arr::get($request_body, 'events'));
+        self::assertNull(Arr::get($request_body, 'enabled'));
+    }
+
+    public function test_enable_webhooks()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->update('random_id', 'https://link.com/webhook', 'Webhook name', [WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], true);
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('PUT', $request->getMethod());
+        self::assertEquals('/v1/webhooks/random_id', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame('https://link.com/webhook', Arr::get($request_body, 'url'));
+        self::assertSame('Webhook name', Arr::get($request_body, 'name'));
+        self::assertSame([WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], Arr::get($request_body, 'events'));
+        self::assertEquals(true, Arr::get($request_body, 'enabled'));
+    }
+
+    public function test_disable_webhooks()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->update('random_id', 'https://link.com/webhook', 'Webhook name', [WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], true);
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('PUT', $request->getMethod());
+        self::assertEquals('/v1/webhooks/random_id', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame('https://link.com/webhook', Arr::get($request_body, 'url'));
+        self::assertSame('Webhook name', Arr::get($request_body, 'name'));
+        self::assertSame([WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], Arr::get($request_body, 'events'));
+        self::assertEquals(true, Arr::get($request_body, 'enabled'));
     }
 }

--- a/tests/Endpoints/WebhookTest.php
+++ b/tests/Endpoints/WebhookTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace MailerSend\Tests\Endpoints;
+
+use Http\Mock\Client;
+use MailerSend\Common\HttpLayer;
+use MailerSend\Endpoints\Webhook;
+use MailerSend\Tests\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Tightenco\Collect\Support\Arr;
+
+class WebhookTest extends TestCase
+{
+    protected Webhook $webhooks;
+    protected ResponseInterface $defaultResponse;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->client = new Client();
+
+        $this->webhooks = new Webhook(new HttpLayer(self::OPTIONS, $this->client), self::OPTIONS);
+        $this->defaultResponse = $this->createMock(ResponseInterface::class);
+        $this->defaultResponse->method('getStatusCode')->willReturn(200);
+    }
+
+    public function test_get_webhooks_domain_id_is_required()
+    {
+        $this->expectExceptionMessage('Domain id is required.');
+
+        $this->webhooks->get('');
+    }
+
+    public function test_find_webhook_is_validated()
+    {
+        $this->expectExceptionMessage('Webhook id is required.');
+
+        $this->webhooks->find('');
+    }
+
+    public function test_delete_webhook_is_validated()
+    {
+        $this->expectExceptionMessage('Webhook id is required.');
+
+        $this->webhooks->delete('');
+    }
+
+    public function test_get_webhooks()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->get('domain_id');
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals('/v1/webhooks', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+
+        self::assertSame('domain_id', Arr::get($request_body, 'domain_id'));
+    }
+
+    public function test_find_webhook()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->find('webhook_id');
+
+        $request = $this->client->getLastRequest();
+
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals('/v1/webhooks/webhook_id', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+    }
+
+    public function test_delete_webhook()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->delete('webhook_id');
+
+        $request = $this->client->getLastRequest();
+
+        self::assertEquals('DELETE', $request->getMethod());
+        self::assertEquals('/v1/webhooks/webhook_id', $request->getUri()->getPath());
+        self::assertEquals(200, $response['status_code']);
+    }
+}


### PR DESCRIPTION
Changelist

- [x] Add support for `GET` & `DELETE` to the `HttpLayer`.
- [x] `Webhooks` list endpoint.
- [x] `Webhooks` find endpoint.
- [x] `Webhooks` delete endpoint.
- [x] `Webhooks` create endpoint.
- [x] `Webhooks` update endpoint.
- [x] Documentation update
- [x] Changelog update

Breaking changes:
- N/A

