### PR TITLE
Do not require both HTML and plain text versions on API and SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ $emailParams = (new EmailParams())
 $mailersend->email->send($emailParams);
 ```
 
+HTML content is not required. You still can send an email with Text only.
+
+```php
+use MailerSend\MailerSend;
+use MailerSend\Helpers\Builder\Recipient;
+use MailerSend\Helpers\Builder\EmailParams;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
+$recipients = [
+    new Recipient('your@client.com', 'Your Client'),
+];
+
+$emailParams = (new EmailParams())
+    ->setFrom('your@domain.com')
+    ->setFromName('Your Name')
+    ->setRecipients($recipients)
+    ->setSubject('Subject')
+    ->setText('This is the text content');
+
+$mailersend->email->send($emailParams);
+```
+
 <a name="cc_and_bcc"></a>
 ## Sending an email with CC and BCC
 

--- a/src/Endpoints/Email.php
+++ b/src/Endpoints/Email.php
@@ -22,8 +22,8 @@ class Email extends AbstractEndpoint
     public function send(EmailParams $params): array
     {
         GeneralHelpers::assert(fn () => Assertion::notEmpty(array_filter([
-            $params->getTemplateId(), $params->getHtml(), $params->getText()
-        ], fn ($v) => $v !== null), 'One of template_id, html or text must be supplied'));
+            $params->getTemplateId(), $params->getText()
+        ], fn ($v) => $v !== null), 'One of template_id or text must be supplied'));
 
         if (!$params->getTemplateId()) {
             GeneralHelpers::assert(

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -217,7 +217,7 @@ class EmailTest extends TestCase
                         new Recipient('recipient@mailersend.com', 'Recipient')
                     ])
                     ->setSubject('Subject')
-                    ->setHtml('HTML'),
+                    ->setText('TEXT'),
             ],
             'using attachments helper' => [
                 (new EmailParams())
@@ -297,7 +297,7 @@ class EmailTest extends TestCase
                         new Recipient('cc@mailersend.com', 'CC')
                     ])
                     ->setSubject('Subject')
-                    ->setHtml('HTML'),
+                    ->setText('TEXT'),
             ],
             'with bcc' => [
                 (new EmailParams())
@@ -312,7 +312,23 @@ class EmailTest extends TestCase
                         new Recipient('bcc@mailersend.com', 'BCC')
                     ])
                     ->setSubject('Subject')
-                    ->setHtml('HTML'),
+                    ->setText('TEXT'),
+            ],
+
+            'without html' => [
+                (new EmailParams())
+                    ->setFrom('test@mailersend.com')
+                    ->setFromName('Sender')
+                    ->setReplyTo('reply-to@mailersend.com')
+                    ->setReplyToName('Reply To')
+                    ->setRecipients([
+                        [
+                            'name' => 'Recipient',
+                            'email' => 'recipient@mailersend.com',
+                        ]
+                    ])
+                    ->setSubject('Subject')
+                    ->setText('Text')
             ]
         ];
     }
@@ -535,6 +551,22 @@ class EmailTest extends TestCase
                     ])
                     ->setSubject('Subject')
                     ->setHtml('HTML'),
+            ],
+
+            'without text param' => [
+                (new EmailParams())
+                    ->setFrom('test@mailersend.com')
+                    ->setFromName('Sender')
+                    ->setReplyTo('reply-to@mailersend.com')
+                    ->setReplyToName('Reply To')
+                    ->setRecipients([
+                        [
+                            'name' => 'Recipient',
+                            'email' => 'recipient@mailersend.com',
+                        ]
+                    ])
+                    ->setSubject('Subject')
+                    ->setHtml('HTML')
             ],
         ];
     }

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -56,7 +56,7 @@ class EmailTest extends TestCase
                 ]
             ])
             ->setSubject('Subject')
-            ->setHtml('HTML');
+            ->setText('TEXT');
 
         $this->email->send($emailParams);
     }


### PR DESCRIPTION
Part of https://github.com/mailersend/mailersend/issues/1971 resolution

Changelist:

- [X] Makes html param optional
- [X] Add test cases
- [X] Fix some existing tests
- [x] `README.md`