### PR TITLE
Add the `domain_id` to the delete endpoint of suppression lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add the `domain_id` to the delete endpoint of suppression lists
+
 ### Fixed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -990,10 +990,10 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->blocklist->delete(['id_one', 'id_two']);
+$mailersend->blocklist->delete('domain_id', ['id_one', 'id_two']);
 
 // or delete all
-$mailersend->blocklist->delete(null, true);
+$mailersend->blocklist->delete('domain_id', null, true);
 ```
 
 **Hard Bounces**
@@ -1004,10 +1004,10 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->hardBounce->delete(['id_one', 'id_two']);
+$mailersend->hardBounce->delete('domain_id', ['id_one', 'id_two']);
 
 // or delete all
-$mailersend->hardBounce->delete(null, true);
+$mailersend->hardBounce->delete('domain_id', null, true);
 ```
 
 **Spam Complaints**
@@ -1018,10 +1018,10 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->spamComplaint->delete(['id_one', 'id_two']);
+$mailersend->spamComplaint->delete('domain_id', ['id_one', 'id_two']);
 
 // or delete all
-$mailersend->spamComplaint->delete(null, true);
+$mailersend->spamComplaint->delete('domain_id', null, true);
 ```
 
 **Unsubscribes**
@@ -1032,10 +1032,10 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->unsubscribe->delete(['id_one', 'id_two']);
+$mailersend->unsubscribe->delete('domain_id', ['id_one', 'id_two']);
 
 // or delete all
-$mailersend->unsubscribe->delete(null, true);
+$mailersend->unsubscribe->delete('domain_id', null, true);
 ```
 
 <a name="get-recipients-from-a-suppression-list"></a>

--- a/README.md
+++ b/README.md
@@ -990,10 +990,13 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->blocklist->delete('domain_id', ['id_one', 'id_two']);
+$mailersend->blocklist->delete(['id_one', 'id_two']);
 
 // or delete all
-$mailersend->blocklist->delete('domain_id', null, true);
+$mailersend->blocklist->delete(null, true);
+
+// You can also specify the domain
+$mailersend->blocklist->delete(['id'], false, 'domain_id');
 ```
 
 **Hard Bounces**
@@ -1008,6 +1011,9 @@ $mailersend->hardBounce->delete('domain_id', ['id_one', 'id_two']);
 
 // or delete all
 $mailersend->hardBounce->delete('domain_id', null, true);
+
+// You can also specify the domain
+$mailersend->hardBounce->delete(['id'], false, 'domain_id');
 ```
 
 **Spam Complaints**
@@ -1022,6 +1028,9 @@ $mailersend->spamComplaint->delete('domain_id', ['id_one', 'id_two']);
 
 // or delete all
 $mailersend->spamComplaint->delete('domain_id', null, true);
+
+// You can also specify the domain
+$mailersend->spamComplaint->delete(['id'], false, 'domain_id');
 ```
 
 **Unsubscribes**
@@ -1036,6 +1045,9 @@ $mailersend->unsubscribe->delete('domain_id', ['id_one', 'id_two']);
 
 // or delete all
 $mailersend->unsubscribe->delete('domain_id', null, true);
+
+// You can also specify the domain
+$mailersend->unsubscribe->delete(['id'], false, 'domain_id');
 ```
 
 <a name="get-recipients-from-a-suppression-list"></a>

--- a/README.md
+++ b/README.md
@@ -1007,10 +1007,10 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->hardBounce->delete('domain_id', ['id_one', 'id_two']);
+$mailersend->hardBounce->delete(['id_one', 'id_two']);
 
 // or delete all
-$mailersend->hardBounce->delete('domain_id', null, true);
+$mailersend->hardBounce->delete(null, true);
 
 // You can also specify the domain
 $mailersend->hardBounce->delete(['id'], false, 'domain_id');
@@ -1024,10 +1024,10 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->spamComplaint->delete('domain_id', ['id_one', 'id_two']);
+$mailersend->spamComplaint->delete(['id_one', 'id_two']);
 
 // or delete all
-$mailersend->spamComplaint->delete('domain_id', null, true);
+$mailersend->spamComplaint->delete(null, true);
 
 // You can also specify the domain
 $mailersend->spamComplaint->delete(['id'], false, 'domain_id');
@@ -1041,10 +1041,10 @@ use MailerSend\MailerSend;
 $mailersend = new MailerSend(['api_key' => 'key']);
 
 // Delete specific instances
-$mailersend->unsubscribe->delete('domain_id', ['id_one', 'id_two']);
+$mailersend->unsubscribe->delete(['id_one', 'id_two']);
 
 // or delete all
-$mailersend->unsubscribe->delete('domain_id', null, true);
+$mailersend->unsubscribe->delete(null, true);
 
 // You can also specify the domain
 $mailersend->unsubscribe->delete(['id'], false, 'domain_id');

--- a/src/Endpoints/Blocklist.php
+++ b/src/Endpoints/Blocklist.php
@@ -64,8 +64,12 @@ class Blocklist extends AbstractEndpoint
      * @throws \MailerSend\Exceptions\MailerSendAssertException
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function delete(?array $ids = null, bool $all = false): array
+    public function delete(string $domainId, ?array $ids = null, bool $all = false): array
     {
+        GeneralHelpers::assert(
+            fn () => Assertion::minLength($domainId, 1, 'Domain id is required.')
+        );
+
         GeneralHelpers::assert(
             fn () => Assertion::notEmpty(
                 array_filter([$ids, $all], fn ($v) => $v !== null && ! empty($v)),
@@ -76,6 +80,7 @@ class Blocklist extends AbstractEndpoint
         return $this->httpLayer->delete(
             $this->buildUri($this->endpoint),
             [
+                'domain_id' => $domainId,
                 'ids' => $ids,
                 'all' => $all,
             ]

--- a/src/Endpoints/Blocklist.php
+++ b/src/Endpoints/Blocklist.php
@@ -64,12 +64,8 @@ class Blocklist extends AbstractEndpoint
      * @throws \MailerSend\Exceptions\MailerSendAssertException
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function delete(string $domainId, ?array $ids = null, bool $all = false): array
+    public function delete(?array $ids = null, bool $all = false, ?string $domainId = null): array
     {
-        GeneralHelpers::assert(
-            fn () => Assertion::minLength($domainId, 1, 'Domain id is required.')
-        );
-
         GeneralHelpers::assert(
             fn () => Assertion::notEmpty(
                 array_filter([$ids, $all], fn ($v) => $v !== null && ! empty($v)),
@@ -79,11 +75,11 @@ class Blocklist extends AbstractEndpoint
 
         return $this->httpLayer->delete(
             $this->buildUri($this->endpoint),
-            [
+            array_filter([
                 'domain_id' => $domainId,
                 'ids' => $ids,
                 'all' => $all,
-            ]
+            ], fn ($e) => !is_null($e))
         );
     }
 }

--- a/src/Endpoints/Suppression.php
+++ b/src/Endpoints/Suppression.php
@@ -67,8 +67,12 @@ class Suppression extends AbstractEndpoint
      * @throws \MailerSend\Exceptions\MailerSendAssertException
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function delete(?array $ids = null, bool $all = false): array
+    public function delete(string $domainId, ?array $ids = null, bool $all = false): array
     {
+        GeneralHelpers::assert(
+            fn () => Assertion::minLength($domainId, 1, 'Domain id is required.')
+        );
+
         GeneralHelpers::assert(
             fn () => Assertion::notEmpty(
                 array_filter([$ids, $all], fn ($v) => $v !== null && ! empty($v)),
@@ -79,6 +83,7 @@ class Suppression extends AbstractEndpoint
         return $this->httpLayer->delete(
             $this->buildUri($this->endpoint),
             [
+                'domain_id' => $domainId,
                 'ids' => $ids,
                 'all' => $all,
             ]

--- a/src/Endpoints/Suppression.php
+++ b/src/Endpoints/Suppression.php
@@ -67,12 +67,8 @@ class Suppression extends AbstractEndpoint
      * @throws \MailerSend\Exceptions\MailerSendAssertException
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function delete(string $domainId, ?array $ids = null, bool $all = false): array
+    public function delete(?array $ids = null, bool $all = false, ?string $domainId = null): array
     {
-        GeneralHelpers::assert(
-            fn () => Assertion::minLength($domainId, 1, 'Domain id is required.')
-        );
-
         GeneralHelpers::assert(
             fn () => Assertion::notEmpty(
                 array_filter([$ids, $all], fn ($v) => $v !== null && ! empty($v)),
@@ -82,11 +78,11 @@ class Suppression extends AbstractEndpoint
 
         return $this->httpLayer->delete(
             $this->buildUri($this->endpoint),
-            [
+            array_filter([
                 'domain_id' => $domainId,
                 'ids' => $ids,
                 'all' => $all,
-            ]
+            ], fn ($e) => !is_null($e))
         );
     }
 }

--- a/tests/Endpoints/BlocklistTest.php
+++ b/tests/Endpoints/BlocklistTest.php
@@ -135,9 +135,9 @@ class BlocklistTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->blocklist->delete(
-            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
+            Arr::get($params, 'domain_id'),
         );
 
         $request = $this->client->getLastRequest();
@@ -148,6 +148,7 @@ class BlocklistTest extends TestCase
         self::assertEquals(200, $response['status_code']);
         self::assertSame(Arr::get($params, 'ids'), Arr::get($request_body, 'ids'));
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
+        self::assertSame(Arr::get($params, 'domain_id'), Arr::get($request_body, 'domain_id'));
     }
 
     /**
@@ -159,19 +160,7 @@ class BlocklistTest extends TestCase
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->blocklist->delete('domain_id');
-    }
-
-    /**
-     * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \JsonException
-     */
-    public function test_delete_requires_domain_id(): void
-    {
-        $this->expectException(MailerSendAssertException::class);
-        $this->expectExceptionMessage('Domain id is required.');
-
-        $this->blocklist->delete('', []);
+        $this->blocklist->delete();
     }
 
     public function validGetAllDataProvider(): array
@@ -230,16 +219,20 @@ class BlocklistTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
                     'ids' => ['id']
                 ],
             ],
             'all' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
                     'all' => true,
                 ],
             ],
+            'with domain id' => [
+                'params' => [
+                    'ids' => ['id'],
+                    'domain_id' => 'domain_id',
+                ]
+            ]
         ];
     }
 }

--- a/tests/Endpoints/BlocklistTest.php
+++ b/tests/Endpoints/BlocklistTest.php
@@ -135,6 +135,7 @@ class BlocklistTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->blocklist->delete(
+            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
         );
@@ -149,12 +150,28 @@ class BlocklistTest extends TestCase
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
     }
 
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
     public function test_delete_requires_either_ids_or_all(): void
     {
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->blocklist->delete();
+        $this->blocklist->delete('domain_id');
+    }
+
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
+    public function test_delete_requires_domain_id(): void
+    {
+        $this->expectException(MailerSendAssertException::class);
+        $this->expectExceptionMessage('Domain id is required.');
+
+        $this->blocklist->delete('', []);
     }
 
     public function validGetAllDataProvider(): array
@@ -213,11 +230,13 @@ class BlocklistTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'ids' => ['id']
                 ],
             ],
             'all' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'all' => true,
                 ],
             ],

--- a/tests/Endpoints/HardBounceTest.php
+++ b/tests/Endpoints/HardBounceTest.php
@@ -129,9 +129,9 @@ class HardBounceTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->hardBounce->delete(
-            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
+            Arr::get($params, 'domain_id'),
         );
 
         $request = $this->client->getLastRequest();
@@ -142,6 +142,7 @@ class HardBounceTest extends TestCase
         self::assertEquals(200, $response['status_code']);
         self::assertSame(Arr::get($params, 'ids'), Arr::get($request_body, 'ids'));
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
+        self::assertSame(Arr::get($params, 'domain_id'), Arr::get($request_body, 'domain_id'));
     }
 
     /**
@@ -153,19 +154,7 @@ class HardBounceTest extends TestCase
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->hardBounce->delete('domain_id');
-    }
-
-    /**
-     * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \JsonException
-     */
-    public function test_delete_requires_domain_id(): void
-    {
-        $this->expectException(MailerSendAssertException::class);
-        $this->expectExceptionMessage('Domain id is required.');
-
-        $this->hardBounce->delete('');
+        $this->hardBounce->delete();
     }
 
     public function validGetAllDataProvider(): array
@@ -224,14 +213,18 @@ class HardBounceTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
-                    'ids' => ['id']
+                    'ids' => ['id'],
                 ],
             ],
             'all' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
                     'all' => true,
+                ],
+            ],
+            'with domain id' => [
+                'params' => [
+                    'ids' => ['id'],
+                    'domain_id' => 'domain_id',
                 ],
             ],
         ];

--- a/tests/Endpoints/HardBounceTest.php
+++ b/tests/Endpoints/HardBounceTest.php
@@ -129,6 +129,7 @@ class HardBounceTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->hardBounce->delete(
+            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
         );
@@ -143,12 +144,28 @@ class HardBounceTest extends TestCase
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
     }
 
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
     public function test_delete_requires_either_ids_or_all(): void
     {
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->hardBounce->delete();
+        $this->hardBounce->delete('domain_id');
+    }
+
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
+    public function test_delete_requires_domain_id(): void
+    {
+        $this->expectException(MailerSendAssertException::class);
+        $this->expectExceptionMessage('Domain id is required.');
+
+        $this->hardBounce->delete('');
     }
 
     public function validGetAllDataProvider(): array
@@ -207,11 +224,13 @@ class HardBounceTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'ids' => ['id']
                 ],
             ],
             'all' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'all' => true,
                 ],
             ],

--- a/tests/Endpoints/SpamComplaintTest.php
+++ b/tests/Endpoints/SpamComplaintTest.php
@@ -129,9 +129,9 @@ class SpamComplaintTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->spamComplaint->delete(
-            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
+            Arr::get($params, 'domain_id'),
         );
 
         $request = $this->client->getLastRequest();
@@ -142,6 +142,7 @@ class SpamComplaintTest extends TestCase
         self::assertEquals(200, $response['status_code']);
         self::assertSame(Arr::get($params, 'ids'), Arr::get($request_body, 'ids'));
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
+        self::assertSame(Arr::get($params, 'domain_id'), Arr::get($request_body, 'domain_id'));
     }
 
     /**
@@ -153,19 +154,7 @@ class SpamComplaintTest extends TestCase
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->spamComplaint->delete('domain_id');
-    }
-
-    /**
-     * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \JsonException
-     */
-    public function test_delete_requires_domain_id(): void
-    {
-        $this->expectException(MailerSendAssertException::class);
-        $this->expectExceptionMessage('Domain id is required.');
-
-        $this->spamComplaint->delete('');
+        $this->spamComplaint->delete();
     }
 
     public function validGetAllDataProvider(): array
@@ -224,14 +213,18 @@ class SpamComplaintTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
-                    'ids' => ['id']
+                    'ids' => ['id'],
                 ],
             ],
             'all' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
                     'all' => true,
+                ],
+            ],
+            'with domain id' => [
+                'params' => [
+                    'ids' => ['id'],
+                    'domain_id' => 'domain_id',
                 ],
             ],
         ];

--- a/tests/Endpoints/SpamComplaintTest.php
+++ b/tests/Endpoints/SpamComplaintTest.php
@@ -129,6 +129,7 @@ class SpamComplaintTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->spamComplaint->delete(
+            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
         );
@@ -143,12 +144,28 @@ class SpamComplaintTest extends TestCase
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
     }
 
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
     public function test_delete_requires_either_ids_or_all(): void
     {
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->spamComplaint->delete();
+        $this->spamComplaint->delete('domain_id');
+    }
+
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
+    public function test_delete_requires_domain_id(): void
+    {
+        $this->expectException(MailerSendAssertException::class);
+        $this->expectExceptionMessage('Domain id is required.');
+
+        $this->spamComplaint->delete('');
     }
 
     public function validGetAllDataProvider(): array
@@ -207,11 +224,13 @@ class SpamComplaintTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'ids' => ['id']
                 ],
             ],
             'all' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'all' => true,
                 ],
             ],

--- a/tests/Endpoints/UnsubscribeTest.php
+++ b/tests/Endpoints/UnsubscribeTest.php
@@ -129,6 +129,7 @@ class UnsubscribeTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->unsubscribe->delete(
+            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
         );
@@ -143,12 +144,28 @@ class UnsubscribeTest extends TestCase
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
     }
 
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
     public function test_delete_requires_either_ids_or_all(): void
     {
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->unsubscribe->delete();
+        $this->unsubscribe->delete('domain_id');
+    }
+
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     */
+    public function test_delete_requires_domain_id(): void
+    {
+        $this->expectException(MailerSendAssertException::class);
+        $this->expectExceptionMessage('Domain id is required.');
+
+        $this->unsubscribe->delete('');
     }
 
     public function validGetAllDataProvider(): array
@@ -207,11 +224,13 @@ class UnsubscribeTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'ids' => ['id']
                 ],
             ],
             'all' => [
                 'params' => [
+                    'domain_id' => 'domain_id',
                     'all' => true,
                 ],
             ],

--- a/tests/Endpoints/UnsubscribeTest.php
+++ b/tests/Endpoints/UnsubscribeTest.php
@@ -129,9 +129,9 @@ class UnsubscribeTest extends TestCase
         $this->client->addResponse($response);
 
         $response = $this->unsubscribe->delete(
-            Arr::get($params, 'domain_id'),
             Arr::get($params, 'ids'),
             Arr::get($params, 'all', false),
+            Arr::get($params, 'domain_id'),
         );
 
         $request = $this->client->getLastRequest();
@@ -142,6 +142,7 @@ class UnsubscribeTest extends TestCase
         self::assertEquals(200, $response['status_code']);
         self::assertSame(Arr::get($params, 'ids'), Arr::get($request_body, 'ids'));
         self::assertSame(Arr::get($params, 'all', false), Arr::get($request_body, 'all'));
+        self::assertSame(Arr::get($params, 'domain_id'), Arr::get($request_body, 'domain_id'));
     }
 
     /**
@@ -153,19 +154,7 @@ class UnsubscribeTest extends TestCase
         $this->expectException(MailerSendAssertException::class);
         $this->expectExceptionMessage('Either ids or all must be provided.');
 
-        $this->unsubscribe->delete('domain_id');
-    }
-
-    /**
-     * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \JsonException
-     */
-    public function test_delete_requires_domain_id(): void
-    {
-        $this->expectException(MailerSendAssertException::class);
-        $this->expectExceptionMessage('Domain id is required.');
-
-        $this->unsubscribe->delete('');
+        $this->unsubscribe->delete();
     }
 
     public function validGetAllDataProvider(): array
@@ -224,14 +213,18 @@ class UnsubscribeTest extends TestCase
         return [
             'with ids' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
-                    'ids' => ['id']
+                    'ids' => ['id'],
                 ],
             ],
             'all' => [
                 'params' => [
-                    'domain_id' => 'domain_id',
                     'all' => true,
+                ],
+            ],
+            'with domain id' => [
+                'params' => [
+                    'ids' => ['id'],
+                    'domain_id' => 'domain_id',
                 ],
             ],
         ];


### PR DESCRIPTION
Related to [issue-2787](https://github.com/mailersend/mailersend/issues/2787).

Changelist:

- [x] Add mandatory `domain_id` parameter
- [x] Update tests
- [x] Update changelog
- [x] Update README 