### PR TITLE
Fix for Deprecated Warning in PHP 8.1

### DIFF
--- a/src/Helpers/Builder/Recipient.php
+++ b/src/Helpers/Builder/Recipient.php
@@ -46,6 +46,7 @@ class Recipient implements Arrayable, \JsonSerializable
         ];
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
Fix for Deprecated Warning in PHP 8.1
Deprecated: Return type of MailerSend\Helpers\Builder\Recipient::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

See:
https://php.watch/versions/8.1/internal-method-return-types#ReturnTypeWillChange