### PR TITLE
Typehint jsonSerialize methods to fix deprecation warnings in php 8.1

### DIFF
--- a/src/Helpers/Builder/Attachment.php
+++ b/src/Helpers/Builder/Attachment.php
@@ -68,7 +68,7 @@ class Attachment implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/CatchFilter.php
+++ b/src/Helpers/Builder/CatchFilter.php
@@ -59,7 +59,7 @@ class CatchFilter implements Arrayable, \JsonSerializable
         return $array;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/DomainParams.php
+++ b/src/Helpers/Builder/DomainParams.php
@@ -74,7 +74,7 @@ class DomainParams implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/EmailVerificationParams.php
+++ b/src/Helpers/Builder/EmailVerificationParams.php
@@ -79,7 +79,7 @@ class EmailVerificationParams implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/Filter.php
+++ b/src/Helpers/Builder/Filter.php
@@ -32,7 +32,7 @@ class Filter implements Arrayable, \JsonSerializable
         return $array;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/Forward.php
+++ b/src/Helpers/Builder/Forward.php
@@ -23,7 +23,7 @@ class Forward implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/Inbound.php
+++ b/src/Helpers/Builder/Inbound.php
@@ -133,7 +133,7 @@ class Inbound implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/MatchFilter.php
+++ b/src/Helpers/Builder/MatchFilter.php
@@ -59,7 +59,7 @@ class MatchFilter implements Arrayable, \JsonSerializable
         return $array;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/Personalization.php
+++ b/src/Helpers/Builder/Personalization.php
@@ -53,7 +53,7 @@ class Personalization implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/Recipient.php
+++ b/src/Helpers/Builder/Recipient.php
@@ -46,7 +46,7 @@ class Recipient implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/SmsInbound.php
+++ b/src/Helpers/Builder/SmsInbound.php
@@ -102,7 +102,7 @@ class SmsInbound implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/SmsInboundFilter.php
+++ b/src/Helpers/Builder/SmsInboundFilter.php
@@ -23,7 +23,7 @@ class SmsInboundFilter implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/SmsPersonalization.php
+++ b/src/Helpers/Builder/SmsPersonalization.php
@@ -53,7 +53,7 @@ class SmsPersonalization implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/SmsWebhookParams.php
+++ b/src/Helpers/Builder/SmsWebhookParams.php
@@ -152,7 +152,7 @@ class SmsWebhookParams implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/TokenParams.php
+++ b/src/Helpers/Builder/TokenParams.php
@@ -128,7 +128,7 @@ class TokenParams implements Arrayable, JsonSerializable
         ]);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/Variable.php
+++ b/src/Helpers/Builder/Variable.php
@@ -62,7 +62,7 @@ class Variable implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Helpers/Builder/WebhookParams.php
+++ b/src/Helpers/Builder/WebhookParams.php
@@ -156,7 +156,7 @@ class WebhookParams implements Arrayable, \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }


### PR DESCRIPTION
Permanent fixes for all potential instances of,
PHP Deprecated:  Return type of MailerSend\Helpers\Builder\Recipient::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice