### PR TITLE
Allow overriding tracking domain defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow overriding tracking domain defaults
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -428,11 +428,38 @@ $emailParams = (new EmailParams())
 $mailersend->email->send($emailParams);
 ```
 
+### Send an email with tracking
+
+```php
+use MailerSend\MailerSend;
+use MailerSend\Helpers\Builder\Recipient;
+use MailerSend\Helpers\Builder\EmailParams;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
+$recipients = [
+    new Recipient('your@client.com', 'Your Client'),
+];
+
+$emailParams = (new EmailParams())
+    ->setFrom('your@domain.com')
+    ->setFromName('Your Name')
+    ->setRecipients($recipients)
+    ->setSubject('Subject')
+    ->setHtml('This is the HTML content')
+    ->setText('This is the text content')
+    ->setTrackClicks(true)
+    ->setTrackOpens(true)
+    ->setTrackContent(true);
+
+$mailersend->email->send($emailParams);
+```
+
 <a name="bulk-email-api"></a>
 ## Bulk email API
 
 <a name="send-bulk-email"></a>
-###Send bulk email
+### Send bulk email
 
 ```php
 use MailerSend\MailerSend;
@@ -467,7 +494,7 @@ $mailersend->bulkEmail->send($bulkEmailParams);
 ```
 
 <a name="get-bulk-email-status"></a>
-###Get bulk email status
+### Get bulk email status
 
 ```php
 use MailerSend\MailerSend;

--- a/src/Endpoints/Email.php
+++ b/src/Endpoints/Email.php
@@ -55,6 +55,9 @@ class Email extends AbstractEndpoint
                     'send_at' => $params->getSendAt(),
                     'precedence_bulk' => $params->getPrecedenceBulkHeader(),
                     'in-reply-to' => $params->getInReplyToHeader(),
+                    'track_clicks' => $params->trackClicks(),
+                    'track_opens' => $params->trackOpens(),
+                    'track_content' => $params->trackContent(),
                 ],
                 fn ($v) => is_array($v) ? array_filter($v, fn ($v) => $v !== null) : $v !== null
             )

--- a/src/Endpoints/Email.php
+++ b/src/Endpoints/Email.php
@@ -55,9 +55,11 @@ class Email extends AbstractEndpoint
                     'send_at' => $params->getSendAt(),
                     'precedence_bulk' => $params->getPrecedenceBulkHeader(),
                     'in-reply-to' => $params->getInReplyToHeader(),
-                    'track_clicks' => $params->trackClicks(),
-                    'track_opens' => $params->trackOpens(),
-                    'track_content' => $params->trackContent(),
+                    'settings' => [
+                        'track_clicks' => $params->trackClicks(),
+                        'track_opens' => $params->trackOpens(),
+                        'track_content' => $params->trackContent(),
+                    ],
                 ],
                 fn ($v) => is_array($v) ? array_filter($v, fn ($v) => $v !== null) : $v !== null
             )

--- a/src/Helpers/Builder/EmailParams.php
+++ b/src/Helpers/Builder/EmailParams.php
@@ -22,9 +22,9 @@ class EmailParams
     protected ?int $send_at = null;
     protected ?bool $precedenceBulkHeader = null;
     protected ?string $inReplyToHeader = null;
-    protected bool $trackClicks = false;
-    protected bool $trackOpens = false;
-    protected bool $trackContent = false;
+    protected ?bool $trackClicks = null;
+    protected ?bool $trackOpens = null;
+    protected ?bool $trackContent = null;
 
     public function getFrom(): ?string
     {
@@ -227,7 +227,7 @@ class EmailParams
         return $this;
     }
 
-    public function trackClicks(): bool
+    public function trackClicks(): ?bool
     {
         return $this->trackClicks;
     }
@@ -239,7 +239,7 @@ class EmailParams
         return $this;
     }
 
-    public function trackOpens(): bool
+    public function trackOpens(): ?bool
     {
         return $this->trackOpens;
     }
@@ -251,7 +251,7 @@ class EmailParams
         return $this;
     }
 
-    public function trackContent(): bool
+    public function trackContent(): ?bool
     {
         return $this->trackContent;
     }

--- a/src/Helpers/Builder/EmailParams.php
+++ b/src/Helpers/Builder/EmailParams.php
@@ -22,6 +22,9 @@ class EmailParams
     protected ?int $send_at = null;
     protected ?bool $precedenceBulkHeader = null;
     protected ?string $inReplyToHeader = null;
+    protected bool $trackClicks = false;
+    protected bool $trackOpens = false;
+    protected bool $trackContent = false;
 
     public function getFrom(): ?string
     {
@@ -220,6 +223,42 @@ class EmailParams
     public function setInReplyToHeader(?string $inReplyToHeader): self
     {
         $this->inReplyToHeader = $inReplyToHeader;
+
+        return $this;
+    }
+
+    public function trackClicks(): bool
+    {
+        return $this->trackClicks;
+    }
+
+    public function setTrackClicks(bool $trackClicks): self
+    {
+        $this->trackClicks = $trackClicks;
+
+        return $this;
+    }
+
+    public function trackOpens(): bool
+    {
+        return $this->trackOpens;
+    }
+
+    public function setTrackOpens(bool $trackOpens): self
+    {
+        $this->trackOpens = $trackOpens;
+
+        return $this;
+    }
+
+    public function trackContent(): bool
+    {
+        return $this->trackContent;
+    }
+
+    public function setTrackContent(bool $trackContent): self
+    {
+        $this->trackContent = $trackContent;
 
         return $this;
     }

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -78,11 +78,6 @@ class EmailTest extends TestCase
                     $recipients[0]->toArray()
                 ],
                 'template_id' => 'templateId',
-                'settings' => [
-                    'track_clicks' => false,
-                    'track_opens' => false,
-                    'track_content' => false,
-                ],
             ])
             ->willReturn([]);
 

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -77,7 +77,12 @@ class EmailTest extends TestCase
                 'to' => [
                     $recipients[0]->toArray()
                 ],
-                'template_id' => 'templateId'
+                'template_id' => 'templateId',
+                'settings' => [
+                    'track_clicks' => false,
+                    'track_opens' => false,
+                    'track_content' => false,
+                ],
             ])
             ->willReturn([]);
 
@@ -169,6 +174,9 @@ class EmailTest extends TestCase
         self::assertEquals($emailParams->getSendAt(), Arr::get($request_body, 'send_at'));
         self::assertEquals($emailParams->getPrecedenceBulkHeader(), Arr::get($request_body, 'precedence_bulk'));
         self::assertEquals($emailParams->getInReplyToHeader(), Arr::get($request_body, 'in-reply-to'));
+        self::assertEquals($emailParams->trackClicks(), Arr::get($request_body, 'settings.track_clicks'));
+        self::assertEquals($emailParams->trackOpens(), Arr::get($request_body, 'settings.track_opens'));
+        self::assertEquals($emailParams->trackContent(), Arr::get($request_body, 'settings.track_content'));
     }
 
     /**
@@ -391,6 +399,25 @@ class EmailTest extends TestCase
                         'tag'
                     ])
                     ->setInReplyToHeader('test@mailersend.com'),
+            ],
+            'with tracking' => [
+                (new EmailParams())
+                    ->setFrom('test@mailersend.com')
+                    ->setFromName('Sender')
+                    ->setReplyTo('reply-to@mailersend.com')
+                    ->setReplyToName('Reply To')
+                    ->setRecipients([
+                        [
+                            'name' => 'Recipient',
+                            'email' => 'recipient@mailersend.com',
+                        ]
+                    ])
+                    ->setSubject('Subject')
+                    ->setHtml('HTML')
+                    ->setText('Text')
+                    ->setTrackClicks(true)
+                    ->setTrackOpens(true)
+                    ->setTrackContent(true)
             ],
         ];
     }


### PR DESCRIPTION
Changelist:

- Add `track_clicks`, `track_opens` and `track_content` to single email sending endpoint
- Update README
- Update Changelog
- Tests