### PR TITLE
hotfix/the set event and tags as array

### DIFF
--- a/src/Endpoints/Webhook.php
+++ b/src/Endpoints/Webhook.php
@@ -61,7 +61,7 @@ class Webhook extends AbstractEndpoint
             array_filter([
                 'url' => $url,
                 'name' => $name,
-                'events' => $events,
+                'events[]' => $events,
                 'enabled' => $enabled,
             ])
         );

--- a/src/Helpers/BuildUri.php
+++ b/src/Helpers/BuildUri.php
@@ -17,7 +17,7 @@ class BuildUri
 
         foreach ($params as $key => $value) {
             if (is_array($value)) {
-                $value = implode(',', $value);
+                $value = implode("&$key=", $value);
             }
 
             $paramsArray[] = $key.'='.$value;

--- a/src/Helpers/Builder/ActivityAnalyticsParams.php
+++ b/src/Helpers/Builder/ActivityAnalyticsParams.php
@@ -88,8 +88,8 @@ class ActivityAnalyticsParams
             'date_from' => $this->getDateFrom(),
             'date_to' => $this->getDateTo(),
             'group_by' => $this->getGroupBy(),
-            'tags' => $this->getTags(),
-            'event' => $this->getEvent(),
+            'tags[]' => $this->getTags(),
+            'event[]' => $this->getEvent(),
         ];
     }
 }

--- a/src/Helpers/Builder/OpensAnalyticsParams.php
+++ b/src/Helpers/Builder/OpensAnalyticsParams.php
@@ -67,7 +67,7 @@ class OpensAnalyticsParams
             'domain_id' => $this->getDomainId(),
             'date_from' => $this->getDateFrom(),
             'date_to' => $this->getDateTo(),
-            'tags' => $this->getTags(),
+            'tags[]' => $this->getTags(),
         ];
     }
 }

--- a/src/Helpers/Builder/SmsWebhookParams.php
+++ b/src/Helpers/Builder/SmsWebhookParams.php
@@ -146,7 +146,7 @@ class SmsWebhookParams implements Arrayable, \JsonSerializable
         return [
             'url' => $this->getUrl(),
             'name' => $this->getName(),
-            'events' => $this->getEvents(),
+            'events[]' => $this->getEvents(),
             'enabled' => $this->getEnabled(),
             'sms_number_id' => $this->getSmsNumberId(),
         ];

--- a/src/Helpers/Builder/WebhookParams.php
+++ b/src/Helpers/Builder/WebhookParams.php
@@ -150,7 +150,7 @@ class WebhookParams implements Arrayable, \JsonSerializable
         return [
             'url' => $this->getUrl(),
             'name' => $this->getName(),
-            'events' => $this->getEvents(),
+            'events[]' => $this->getEvents(),
             'enabled' => $this->getEnabled(),
             'domain_id' => $this->getDomainId(),
         ];


### PR DESCRIPTION
make the set events and the set tags readable as arrays in the package, instead of reading it as non-array variable, which caused a syntax error while using the package in a Laravel project.