### PR TITLE
Adding support for psr/http-message v.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated psr/http-message to include version v.2.0
-- Updated guzzlehttp/psr7 to v.2.5.0
+- Added support for psr/http-message to include version v.2.0
+- Added support for guzzlehttp/psr7 to v.2.5.0 - as required per psr/http-message v.2.0
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated psr/http-message to include version v.2.0
+- Updated guzzlehttp/psr7 to v.2.5.0
+
 ### Fixed
 
 ### Removed
@@ -50,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade PHPCSFixer to v3
-- Allow overriding tracking domain defaults 
+- Allow overriding tracking domain defaults
 
 ### Fixed
 
@@ -210,7 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPUnit tests
 - Documentation
 
-[Unreleased]: https://github.com/mailersend/mailersend-php/compare/v0.10.0...HEAD
+[unreleased]: https://github.com/mailersend/mailersend-php/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/mailersend/mailersend-php/releases/tag/v0.10.0
 [0.9.1]: https://github.com/mailersend/mailersend-php/releases/tag/v0.9.1
 [0.9.0]: https://github.com/mailersend/mailersend-php/releases/tag/v0.9.0

--- a/composer.json
+++ b/composer.json
@@ -59,9 +59,6 @@
     ]
   },
   "config": {
-    "platform-check": false,
-    "allow-plugins": {
-      "php-http/discovery": true
-    }
+    "platform-check": false
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php-http/discovery": "^1.9",
     "php-http/httplug": "^2.1",
     "psr/http-client-implementation": "^1.0",
-    "psr/http-message": "^2.0",
+    "psr/http-message": "^1.0|^2.0",
     "tightenco/collect": "^7.0|^8.0",
     "beberlei/assert": "^3.2",
     "symfony/symfony": "^5.4.16"
@@ -35,7 +35,7 @@
     "php-http/mock-client": "^1.0",
     "php-http/message": "^1.0",
     "mockery/mockery": "^0.9.4",
-    "guzzlehttp/psr7": "^2.5.0",
+    "guzzlehttp/psr7": "^1.5.2|^2.5.0",
     "http-interop/http-factory-guzzle": "^1.0",
     "php-http/guzzle7-adapter": "^0.1",
     "friendsofphp/php-cs-fixer": "^3.4.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php-http/discovery": "^1.9",
     "php-http/httplug": "^2.1",
     "psr/http-client-implementation": "^1.0",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^2.0",
     "tightenco/collect": "^7.0|^8.0",
     "beberlei/assert": "^3.2",
     "symfony/symfony": "^5.4.16"
@@ -35,7 +35,7 @@
     "php-http/mock-client": "^1.0",
     "php-http/message": "^1.0",
     "mockery/mockery": "^0.9.4",
-    "guzzlehttp/psr7": "^1.5.2",
+    "guzzlehttp/psr7": "^2.5.0",
     "http-interop/http-factory-guzzle": "^1.0",
     "php-http/guzzle7-adapter": "^0.1",
     "friendsofphp/php-cs-fixer": "^3.4.0"
@@ -59,6 +59,9 @@
     ]
   },
   "config": {
-    "platform-check": false
+    "platform-check": false,
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   }
 }


### PR DESCRIPTION
I ran into this Composer require issue, on a private project of mine (using Laravel 10):

_>  Problem 1
>     - mailersend/mailersend v0.8.0 requires psr/http-message ^1.0 -> found psr/http-message[1.0, 1.0.1, 1.1] but the package is fixed to 2.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
>     - mailersend/laravel-driver v2.2.0 requires mailersend/mailersend ^0.8.0 -> satisfiable by mailersend/mailersend[v0.8.0].
>     - Root composer.json requires mailersend/laravel-driver ^2.2 -> satisfiable by mailersend/laravel-driver[v2.2.0]._

In this pull request, I've updated "psr/http-message" to version ^2.0 
Additionally I've updated "guzzlehttp/psr7" to v.2.5.0  - required to be able to use "psr/http-message" v. 2.0

Ran "composer run test" locally - result: All ok.

Note: 
This is my first ever contribution attempt. 
So please guide me if doing something wrong / missing something.