### PR TITLE
Sending email with only html param should work

### DIFF
--- a/src/Helpers/GeneralHelpers.php
+++ b/src/Helpers/GeneralHelpers.php
@@ -31,8 +31,8 @@ class GeneralHelpers
     public static function validateEmailParams(EmailParams $params): void
     {
         self::assert(fn () => Assertion::notEmpty(array_filter([
-            $params->getTemplateId(), $params->getText()
-        ], fn ($v) => $v !== null), 'One of template_id or text must be supplied'));
+            $params->getTemplateId(), $params->getText(), $params->getHtml()
+        ], fn ($v) => $v !== null), 'One of template_id, html or text must be supplied'));
 
         if (!$params->getTemplateId()) {
             self::assert(

--- a/tests/Endpoints/BulkEmailTest.php
+++ b/tests/Endpoints/BulkEmailTest.php
@@ -812,7 +812,6 @@ class BulkEmailTest extends TestCase
                             ]
                         ])
                         ->setSubject('Subject')
-                        ->setHtml('HTML')
                 ]
             ],
         ];

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -652,7 +652,6 @@ class EmailTest extends TestCase
                         ]
                     ])
                     ->setSubject('Subject')
-                    ->setHtml('HTML')
             ],
         ];
     }


### PR DESCRIPTION
resolves https://github.com/mailersend/mailersend-laravel-driver/issues/31#issuecomment-1668613702

- [ ] Validate email params should also check html param



