### PR TITLE
Fetching analytics and activities with event and tag array does not work

### DIFF
--- a/src/Endpoints/Activity.php
+++ b/src/Endpoints/Activity.php
@@ -39,7 +39,7 @@ class Activity extends AbstractEndpoint
             );
         }
 
-        if (! empty($activityParams->getEvent())) {
+        if (!empty($activityParams->getEvent())) {
             $diff = array_diff($activityParams->getEvent(), Constants::POSSIBLE_EVENT_TYPES);
             GeneralHelpers::assert(
                 fn () => Assertion::count($diff, 0, 'The following types are invalid: ' . implode(', ', $diff))

--- a/src/Endpoints/Activity.php
+++ b/src/Endpoints/Activity.php
@@ -47,6 +47,6 @@ class Activity extends AbstractEndpoint
         }
 
 
-        return $this->httpLayer->get($this->buildUri("$this->endpoint/$domainId", $activityParams->toArray()));
+        return $this->httpLayer->get($this->url("$this->endpoint/$domainId", $activityParams->toArray()));
     }
 }

--- a/src/Endpoints/Analytics.php
+++ b/src/Endpoints/Analytics.php
@@ -48,7 +48,7 @@ class Analytics extends AbstractEndpoint
         }
 
         return $this->httpLayer->get(
-            $this->buildUri("$this->endpoint/date", $activityAnalyticsParams->toArray())
+            $this->url("$this->endpoint/date", $activityAnalyticsParams->toArray())
         );
     }
 
@@ -83,7 +83,7 @@ class Analytics extends AbstractEndpoint
         );
 
         return $this->httpLayer->get(
-            $this->buildUri($path, $opensAnalyticsParams->toArray())
+            $this->url($path, $opensAnalyticsParams->toArray())
         );
     }
 }

--- a/src/Endpoints/Blocklist.php
+++ b/src/Endpoints/Blocklist.php
@@ -47,7 +47,7 @@ class Blocklist extends AbstractEndpoint
     {
         GeneralHelpers::assert(
             fn () => Assertion::notEmpty(
-                array_filter([$params->getRecipients(), $params->getPatterns()], fn ($v) => ! empty($v)),
+                array_filter([$params->getRecipients(), $params->getPatterns()], fn ($v) => !empty($v)),
                 'Either recipients or patterns must be provided.'
             )
             && Assertion::minLength($params->getDomainId(), 1, 'Domain id is required.')
@@ -68,7 +68,7 @@ class Blocklist extends AbstractEndpoint
     {
         GeneralHelpers::assert(
             fn () => Assertion::notEmpty(
-                array_filter([$ids, $all], fn ($v) => $v !== null && ! empty($v)),
+                array_filter([$ids, $all], fn ($v) => $v !== null && !empty($v)),
                 'Either ids or all must be provided.'
             )
         );

--- a/src/Endpoints/SmsActivity.php
+++ b/src/Endpoints/SmsActivity.php
@@ -42,7 +42,7 @@ class SmsActivity extends AbstractEndpoint
             );
         }
 
-        if (! empty($smsActivityParams->getStatus())) {
+        if (!empty($smsActivityParams->getStatus())) {
             $diff = array_diff($smsActivityParams->getStatus(), Constants::POSSIBLE_SMS_STATUSES);
             GeneralHelpers::assert(
                 fn () => Assertion::count($diff, 0, 'The following statuses are invalid: ' . implode(', ', $diff))

--- a/src/Endpoints/Suppression.php
+++ b/src/Endpoints/Suppression.php
@@ -71,7 +71,7 @@ class Suppression extends AbstractEndpoint
     {
         GeneralHelpers::assert(
             fn () => Assertion::notEmpty(
-                array_filter([$ids, $all], fn ($v) => $v !== null && ! empty($v)),
+                array_filter([$ids, $all], fn ($v) => $v !== null && !empty($v)),
                 'Either ids or all must be provided.'
             )
         );

--- a/src/Helpers/GeneralHelpers.php
+++ b/src/Helpers/GeneralHelpers.php
@@ -48,7 +48,7 @@ class GeneralHelpers
         if (count($params->getCc()) > 0) {
             self::assert(fn () => Assertion::maxCount($params->getCc(), 10));
             foreach ($params->getCc() as $key => $cc) {
-                $cc = ! is_array($cc) ? $cc->toArray() : $cc;
+                $cc = !is_array($cc) ? $cc->toArray() : $cc;
                 self::assert(
                     fn () => Assertion::keyExists($cc, 'email', "The element with index $key in CC array does not contain the email parameter.")
                 );
@@ -62,7 +62,7 @@ class GeneralHelpers
         if (count($params->getBcc()) > 0) {
             self::assert(fn () => Assertion::maxCount($params->getBcc(), 10));
             foreach ($params->getBcc() as $key => $bcc) {
-                $bcc = ! is_array($bcc) ? $bcc->toArray() : $bcc;
+                $bcc = !is_array($bcc) ? $bcc->toArray() : $bcc;
                 self::assert(
                     fn () => Assertion::keyExists($bcc, 'email', "The element with index $key in BCC array does not contain the email parameter.")
                 );

--- a/tests/Endpoints/ActivityTest.php
+++ b/tests/Endpoints/ActivityTest.php
@@ -55,7 +55,7 @@ class ActivityTest extends TestCase
         self::assertEquals($activityParams->getLimit(), Arr::get($query, 'limit'));
         self::assertEquals($activityParams->getDateFrom(), Arr::get($query, 'date_from'));
         self::assertEquals($activityParams->getDateTo(), Arr::get($query, 'date_to'));
-        self::assertEquals(implode(',', $activityParams->getEvent()), Arr::get($query, 'event'));
+        self::assertCount(count($activityParams->getEvent()), Arr::get($query, 'event') ?? []);
     }
 
     /**

--- a/tests/Endpoints/AnalyticsTest.php
+++ b/tests/Endpoints/AnalyticsTest.php
@@ -54,8 +54,14 @@ class AnalyticsTest extends TestCase
         self::assertEquals($activityAnalyticsParams->getDateFrom(), Arr::get($query, 'date_from'));
         self::assertEquals($activityAnalyticsParams->getDateTo(), Arr::get($query, 'date_to'));
         self::assertEquals($activityAnalyticsParams->getGroupBy(), Arr::get($query, 'group_by'));
-        self::assertEquals(implode(',', $activityAnalyticsParams->getTags()), Arr::get($query, 'tags'));
-        self::assertEquals(implode(',', $activityAnalyticsParams->getEvent()), Arr::get($query, 'event'));
+        self::assertCount(count($activityAnalyticsParams->getTags()), Arr::get($query, 'tags') ?? []);
+        self::assertCount(count($activityAnalyticsParams->getEvent()), Arr::get($query, 'event') ?? []);
+        foreach ($activityAnalyticsParams->getTags() as $key => $tag) {
+            self::assertEquals($tag, Arr::get($query, "tags.$key"));
+        }
+        foreach ($activityAnalyticsParams->getEvent() as $key => $event) {
+            self::assertEquals($event, Arr::get($query, "event.$key"));
+        }
     }
 
     /**
@@ -137,7 +143,10 @@ class AnalyticsTest extends TestCase
         self::assertEquals($opensAnalyticsParams->getDomainId(), Arr::get($query, 'domain_id'));
         self::assertEquals($opensAnalyticsParams->getDateFrom(), Arr::get($query, 'date_from'));
         self::assertEquals($opensAnalyticsParams->getDateTo(), Arr::get($query, 'date_to'));
-        self::assertEquals(implode(',', $opensAnalyticsParams->getTags()), Arr::get($query, 'tags'));
+        self::assertCount(count($opensAnalyticsParams->getTags()), Arr::get($query, 'tags') ?? []);
+        foreach ($opensAnalyticsParams->getTags() as $key => $tag) {
+            self::assertEquals($tag, Arr::get($query, "tags.$key"));
+        }
     }
 
     /**
@@ -163,7 +172,10 @@ class AnalyticsTest extends TestCase
         self::assertEquals($opensAnalyticsParams->getDomainId(), Arr::get($query, 'domain_id'));
         self::assertEquals($opensAnalyticsParams->getDateFrom(), Arr::get($query, 'date_from'));
         self::assertEquals($opensAnalyticsParams->getDateTo(), Arr::get($query, 'date_to'));
-        self::assertEquals(implode(',', $opensAnalyticsParams->getTags()), Arr::get($query, 'tags'));
+        self::assertCount(count($opensAnalyticsParams->getTags()), Arr::get($query, 'tags') ?? []);
+        foreach ($opensAnalyticsParams->getTags() as $key => $tag) {
+            self::assertEquals($tag, Arr::get($query, "tags.$key"));
+        }
     }
 
     /**
@@ -189,7 +201,10 @@ class AnalyticsTest extends TestCase
         self::assertEquals($opensAnalyticsParams->getDomainId(), Arr::get($query, 'domain_id'));
         self::assertEquals($opensAnalyticsParams->getDateFrom(), Arr::get($query, 'date_from'));
         self::assertEquals($opensAnalyticsParams->getDateTo(), Arr::get($query, 'date_to'));
-        self::assertEquals(implode(',', $opensAnalyticsParams->getTags()), Arr::get($query, 'tags'));
+        self::assertCount(count($opensAnalyticsParams->getTags()), Arr::get($query, 'tags') ?? []);
+        foreach ($opensAnalyticsParams->getTags() as $key => $tag) {
+            self::assertEquals($tag, Arr::get($query, "tags.$key"));
+        }
     }
 
     public function validOpensAnalyticsProvider(): array

--- a/tests/Endpoints/BulkEmailTest.php
+++ b/tests/Endpoints/BulkEmailTest.php
@@ -93,21 +93,21 @@ class BulkEmailTest extends TestCase
             self::assertCount(count($emailParams->getRecipients()), Arr::get($request_body, "$key.to"));
 
             foreach ($emailParams->getRecipients() as $k => $recipient) {
-                $recipient = ! is_array($recipient) ? $recipient->toArray() : $recipient;
+                $recipient = !is_array($recipient) ? $recipient->toArray() : $recipient;
                 self::assertEquals($recipient['name'], Arr::get($request_body, "$key.to.$k.name"));
                 self::assertEquals($recipient['email'], Arr::get($request_body, "$key.to.$k.email"));
             }
 
             self::assertCount(count($emailParams->getCc()), Arr::get($request_body, "$key.cc") ?? []);
             foreach ($emailParams->getCc() as $k => $cc) {
-                $cc = ! is_array($cc) ? $cc->toArray() : $cc;
+                $cc = !is_array($cc) ? $cc->toArray() : $cc;
                 self::assertEquals($cc['name'], Arr::get($request_body, "$key.cc.$k.name"));
                 self::assertEquals($cc['email'], Arr::get($request_body, "$key.cc.$k.email"));
             }
 
             self::assertCount(count($emailParams->getBcc()), Arr::get($request_body, "$key.bcc") ?? []);
             foreach ($emailParams->getBcc() as $k => $bcc) {
-                $bcc = ! is_array($bcc) ? $bcc->toArray() : $bcc;
+                $bcc = !is_array($bcc) ? $bcc->toArray() : $bcc;
                 self::assertEquals($bcc['name'], Arr::get($request_body, "$key.bcc.$k.name"));
                 self::assertEquals($bcc['email'], Arr::get($request_body, "$key.bcc.$k.email"));
             }
@@ -121,7 +121,7 @@ class BulkEmailTest extends TestCase
             self::assertEquals($emailParams->getTemplateId(), Arr::get($request_body, "$key.template_id"));
             self::assertCount(count($emailParams->getVariables()), Arr::get($request_body, "$key.variables") ?? []);
             foreach ($emailParams->getVariables() as $variableKey => $variable) {
-                $variable = ! is_array($variable) ? $variable->toArray() : $variable;
+                $variable = !is_array($variable) ? $variable->toArray() : $variable;
                 self::assertEquals($variable['email'], Arr::get($request_body, "$key.variables.$variableKey.email"));
                 foreach ($variable['substitutions'] as $substitutionKey => $substitution) {
                     self::assertEquals($substitution['var'], Arr::get($request_body, "$key.variables.$variableKey.substitutions.$substitutionKey.var"));
@@ -130,7 +130,7 @@ class BulkEmailTest extends TestCase
             }
             self::assertCount(count($emailParams->getAttachments()), Arr::get($request_body, "$key.attachments") ?? []);
             foreach ($emailParams->getAttachments() as $k => $attachment) {
-                $attachment = ! is_array($attachment) ? $attachment->toArray() : $attachment;
+                $attachment = !is_array($attachment) ? $attachment->toArray() : $attachment;
                 self::assertEquals($attachment['content'], Arr::get($request_body, "$key.attachments.$k.content"));
                 self::assertEquals($attachment['filename'], Arr::get($request_body, "$key.attachments.$k.filename"));
                 self::assertEquals($attachment['disposition'], Arr::get($request_body, "$key.attachments.$k.disposition"));
@@ -139,7 +139,7 @@ class BulkEmailTest extends TestCase
 
             self::assertCount(count($emailParams->getPersonalization()), Arr::get($request_body, "$key.personalization") ?? []);
             foreach ($emailParams->getPersonalization() as $k => $personalization) {
-                $personalization = ! is_array($personalization) ? $personalization->toArray() : $personalization;
+                $personalization = !is_array($personalization) ? $personalization->toArray() : $personalization;
                 self::assertEquals($personalization['email'], Arr::get($request_body, "$key.personalization.$k.email"));
                 foreach ($personalization['data'] as $variableKey => $variableValue) {
                     self::assertEquals($personalization['data'][$variableKey], Arr::get($request_body, "$key.personalization.$k.data.$variableKey"));

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -118,19 +118,19 @@ class EmailTest extends TestCase
         self::assertEquals($emailParams->getReplyToName(), Arr::get($request_body, 'reply_to.name'));
         self::assertCount(count($emailParams->getRecipients()), Arr::get($request_body, 'to'));
         foreach ($emailParams->getRecipients() as $key => $recipient) {
-            $recipient = ! is_array($recipient) ? $recipient->toArray() : $recipient;
+            $recipient = !is_array($recipient) ? $recipient->toArray() : $recipient;
             self::assertEquals($recipient['name'], Arr::get($request_body, "to.$key.name"));
             self::assertEquals($recipient['email'], Arr::get($request_body, "to.$key.email"));
         }
         self::assertCount(count($emailParams->getCc()), Arr::get($request_body, 'cc') ?? []);
         foreach ($emailParams->getCc() as $key => $cc) {
-            $cc = ! is_array($cc) ? $cc->toArray() : $cc;
+            $cc = !is_array($cc) ? $cc->toArray() : $cc;
             self::assertEquals($cc['name'], Arr::get($request_body, "cc.$key.name"));
             self::assertEquals($cc['email'], Arr::get($request_body, "cc.$key.email"));
         }
         self::assertCount(count($emailParams->getBcc()), Arr::get($request_body, 'bcc') ?? []);
         foreach ($emailParams->getBcc() as $key => $bcc) {
-            $bcc = ! is_array($bcc) ? $bcc->toArray() : $bcc;
+            $bcc = !is_array($bcc) ? $bcc->toArray() : $bcc;
             self::assertEquals($bcc['name'], Arr::get($request_body, "bcc.$key.name"));
             self::assertEquals($bcc['email'], Arr::get($request_body, "bcc.$key.email"));
         }
@@ -144,7 +144,7 @@ class EmailTest extends TestCase
         self::assertEquals($emailParams->getTemplateId(), Arr::get($request_body, 'template_id'));
         self::assertCount(count($emailParams->getVariables()), Arr::get($request_body, 'variables') ?? []);
         foreach ($emailParams->getVariables() as $variableKey => $variable) {
-            $variable = ! is_array($variable) ? $variable->toArray() : $variable;
+            $variable = !is_array($variable) ? $variable->toArray() : $variable;
             self::assertEquals($variable['email'], Arr::get($request_body, "variables.$variableKey.email"));
             foreach ($variable['substitutions'] as $substitutionKey => $substitution) {
                 self::assertEquals($substitution['var'], Arr::get($request_body, "variables.$variableKey.substitutions.$substitutionKey.var"));
@@ -153,7 +153,7 @@ class EmailTest extends TestCase
         }
         self::assertCount(count($emailParams->getAttachments()), Arr::get($request_body, 'attachments') ?? []);
         foreach ($emailParams->getAttachments() as $key => $attachment) {
-            $attachment = ! is_array($attachment) ? $attachment->toArray() : $attachment;
+            $attachment = !is_array($attachment) ? $attachment->toArray() : $attachment;
             self::assertEquals($attachment['content'], Arr::get($request_body, "attachments.$key.content"));
             self::assertEquals($attachment['filename'], Arr::get($request_body, "attachments.$key.filename"));
             self::assertEquals($attachment['disposition'], Arr::get($request_body, "attachments.$key.disposition"));
@@ -162,7 +162,7 @@ class EmailTest extends TestCase
 
         self::assertCount(count($emailParams->getPersonalization()), Arr::get($request_body, 'personalization') ?? []);
         foreach ($emailParams->getPersonalization() as $key => $personalization) {
-            $personalization = ! is_array($personalization) ? $personalization->toArray() : $personalization;
+            $personalization = !is_array($personalization) ? $personalization->toArray() : $personalization;
             self::assertEquals($personalization['email'], Arr::get($request_body, "personalization.$key.email"));
             foreach ($personalization['data'] as $variableKey => $variableValue) {
                 self::assertEquals($personalization['data'][$variableKey], Arr::get($request_body, "personalization.$key.data.$variableKey"));

--- a/tests/Endpoints/SmsTest.php
+++ b/tests/Endpoints/SmsTest.php
@@ -60,7 +60,7 @@ class SmsTest extends TestCase
         self::assertCount(count($smsParams->getPersonalization()), Arr::get($request_body, 'personalization') ?? []);
 
         foreach ($smsParams->getPersonalization() as $key => $personalization) {
-            $personalization = ! is_array($personalization) ? $personalization->toArray() : $personalization;
+            $personalization = !is_array($personalization) ? $personalization->toArray() : $personalization;
             self::assertEquals($personalization['phone_number'], Arr::get($request_body, "personalization.$key.phone_number"));
             foreach ($personalization['data'] as $variableKey => $variableValue) {
                 self::assertEquals($personalization['data'][$variableKey], Arr::get($request_body, "personalization.$key.data.$variableKey"));


### PR DESCRIPTION
resolves #93 

### Changelist
- [x] Change Analytic endpoints to use `url` method instead of `buildUri`
- [x] Change Activity endpoint to use `url` method instead of `buildUri`
- [x] Update Test 
- [x] Code style fixes