### PR TITLE
Allow users to set custom headers to their emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ MailerSend PHP SDK
         * [Send an email with attachment](#attachments)
         * [Send a scheduled message](#send-a-scheduled-message)
         * [Send email with precedence bulk header](#precedence-bulk-header)
+        * [Send email with custom headers](#custom-headers)
     * [Bulk emails API](#bulk-email-api)
         * [Send bulk email](#send-bulk-email)
         * [Get bulk email status](#get-bulk-email-status)
@@ -462,6 +463,38 @@ $emailParams = (new EmailParams())
     ->setTrackClicks(true)
     ->setTrackOpens(true)
     ->setTrackContent(true);
+
+$mailersend->email->send($emailParams);
+```
+
+<a name="custom-headers"></a>
+### Send an email with custom headers
+
+```php
+use MailerSend\MailerSend;
+use MailerSend\Helpers\Builder\Recipient;
+use MailerSend\Helpers\Builder\EmailParams;
+use MailerSend\Helpers\Builder\Header;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
+$recipients = [
+    new Recipient('your@client.com', 'Your Client'),
+];
+
+$headers = [
+    new Header('Custom-Header-1', 'Value 1')
+    new Header('Custom-Header-2', 'Value 2')
+];
+
+$emailParams = (new EmailParams())
+    ->setFrom('your@domain.com')
+    ->setFromName('Your Name')
+    ->setRecipients($recipients)
+    ->setSubject('Subject')
+    ->setHtml('This is the HTML content')
+    ->setText('This is the text content')
+    ->setHeaders($headers);
 
 $mailersend->email->send($emailParams);
 ```

--- a/src/Endpoints/Email.php
+++ b/src/Endpoints/Email.php
@@ -60,6 +60,7 @@ class Email extends AbstractEndpoint
                         'track_opens' => $params->trackOpens(),
                         'track_content' => $params->trackContent(),
                     ],
+                    'headers' => $params->getHeaders(),
                 ],
                 fn ($v) => is_array($v) ? array_filter($v, fn ($v) => $v !== null) : $v !== null
             )

--- a/src/Helpers/Builder/EmailParams.php
+++ b/src/Helpers/Builder/EmailParams.php
@@ -25,6 +25,7 @@ class EmailParams
     protected ?bool $trackClicks = null;
     protected ?bool $trackOpens = null;
     protected ?bool $trackContent = null;
+    protected array $headers = [];
 
     public function getFrom(): ?string
     {
@@ -260,6 +261,17 @@ class EmailParams
     {
         $this->trackContent = $trackContent;
 
+        return $this;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function setHeaders(array $headers): EmailParams
+    {
+        $this->headers = $headers;
         return $this;
     }
 }

--- a/src/Helpers/Builder/Header.php
+++ b/src/Helpers/Builder/Header.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace MailerSend\Helpers\Builder;
+
+use Assert\Assertion;
+use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\GeneralHelpers;
+use Tightenco\Collect\Contracts\Support\Arrayable;
+
+class Header implements Arrayable, \JsonSerializable
+{
+    protected string $name;
+    protected string $value;
+
+    /**
+     * @throws MailerSendAssertException
+     */
+    public function __construct(string $name, string $value)
+    {
+        $this->setName($name);
+        $this->setValue($value);
+    }
+
+    /**
+     * @throws MailerSendAssertException
+     */
+    public function setName(string $name): void
+    {
+        GeneralHelpers::assert(static function () use ($name) {
+            Assertion::notEmpty($name);
+            Assertion::string($name);
+        });
+
+        $this->name = $name;
+    }
+
+    /**
+     * @throws MailerSendAssertException
+     */
+    public function setValue(string $value): void
+    {
+        GeneralHelpers::assert(static function () use ($value) {
+            Assertion::notEmpty($value);
+            Assertion::string($value);
+        });
+
+        $this->value = $value;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'value' => $this->value,
+        ];
+    }
+
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -168,6 +168,12 @@ class EmailTest extends TestCase
                 self::assertEquals($personalization['data'][$variableKey], Arr::get($request_body, "personalization.$key.data.$variableKey"));
             }
         }
+        self::assertCount(count($emailParams->getHeaders()), Arr::get($request_body, 'headers') ?? []);
+        foreach ($emailParams->getHeaders() as $key => $header) {
+            $header = !is_array($header) ? $header->toArray() : $header;
+            self::assertEquals($header['name'], Arr::get($request_body, "headers.$key.name"));
+            self::assertEquals($header['value'], Arr::get($request_body, "headers.$key.value"));
+        }
         self::assertEquals($emailParams->getSendAt(), Arr::get($request_body, 'send_at'));
         self::assertEquals($emailParams->getPrecedenceBulkHeader(), Arr::get($request_body, 'precedence_bulk'));
         self::assertEquals($emailParams->getInReplyToHeader(), Arr::get($request_body, 'in_reply_to'));
@@ -415,6 +421,28 @@ class EmailTest extends TestCase
                     ->setTrackClicks(true)
                     ->setTrackOpens(true)
                     ->setTrackContent(true)
+            ],
+            'with custom headers' => [
+                (new EmailParams())
+                    ->setFrom('test@mailersend.com')
+                    ->setFromName('Sender')
+                    ->setReplyTo('reply-to@mailersend.com')
+                    ->setReplyToName('Reply To')
+                    ->setRecipients([
+                        [
+                            'name' => 'Recipient',
+                            'email' => 'recipient@mailersend.com',
+                        ]
+                    ])
+                    ->setSubject('Subject')
+                    ->setHtml('HTML')
+                    ->setText('Text')
+                    ->setHeaders([
+                        [
+                          'name' => 'Custom-Header-1',
+                          'value' => 'Value 1',
+                        ]
+                    ])
             ],
         ];
     }

--- a/tests/Helpers/Builder/HeaderTest.php
+++ b/tests/Helpers/Builder/HeaderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MailerSend\Tests\Helpers\Builder;
+
+use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\Builder\Header;
+use MailerSend\Tests\TestCase;
+use Tightenco\Collect\Support\Arr;
+
+class HeaderTest extends TestCase
+{
+    public function test_properly_sets_header_params(): void
+    {
+        $header = (new Header('Custom-Header-1', 'Value 1'))->toArray();
+
+        self::assertEquals('Custom-Header-1', Arr::get($header, 'name'));
+        self::assertEquals('Value 1', Arr::get($header, 'value'));
+    }
+
+    public function test_header_validates_empty_name(): void
+    {
+        $this->expectException(MailerSendAssertException::class);
+
+        (new Header('', 'Value 1'));
+    }
+
+    public function test_header_validates_empty_value(): void
+    {
+        $this->expectException(MailerSendAssertException::class);
+
+        (new Header('Custom-Header-1', ''));
+    }
+}


### PR DESCRIPTION
resolves #https://github.com/mailersend/mailersend/issues/2280

### Changelist
- [x] Add headers params when sending email
- [x] Test