### PR TITLE
Remove completely unused Symfony dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "psr/http-client-implementation": "^1.0",
     "psr/http-message": "^1.0 || ^2.0",
     "tightenco/collect": "^7.0|^8.0",
-    "beberlei/assert": "^3.2",
-    "symfony/symfony": "^5.4.16 || ^6.3.4"
+    "beberlei/assert": "^3.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5.15 || ^8.4 || ^9.0",


### PR DESCRIPTION
The Symfony composer depency is created in commit https://github.com/mailersend/mailersend-php/commit/e3d0be351f7877729fd113d15f72c5f4b50bf786 
If you look at the complete source and to the changes in this commit there is no code reference to Symfony at all. So I removed the dependency.
I runned al tests, they work.