### PR TITLE
Add an endpoint to fetch a single email activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ MailerSend PHP SDK
         * [Delete an inbound route](#delete-an-inbound-route)
     * [Activity API](#activity)
         * [Get a list of activities](#get-a-list-of-activities)
+        * [Get a single activity](#get-a-single-activity)
     * [Analytics API](#analytics)
         * [Get activity data by date](#get-activity-data-by-date)
         * [Opens by country](#opens-by-country)
@@ -716,6 +717,19 @@ $activityParams = (new ActivityParams())
                     ->setEvent(['queued', 'sent']);
 
 $mailersend->activity->getAll('domainId', $activityParams);
+```
+
+<a name="#get-a-single-activity"></a>
+
+### Get a single activity
+
+```php
+use MailerSend\MailerSend;
+use MailerSend\Helpers\Builder\ActivityParams;
+
+$mailersend = new MailerSend(['api_key' => 'key']);
+
+$mailersend->activity->find('activity_id');
 ```
 
 <a name="analytics"></a>

--- a/src/Endpoints/Activity.php
+++ b/src/Endpoints/Activity.php
@@ -49,4 +49,20 @@ class Activity extends AbstractEndpoint
 
         return $this->httpLayer->get($this->url("$this->endpoint/$domainId", $activityParams->toArray()));
     }
+
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \JsonException
+     * @throws \MailerSend\Exceptions\MailerSendAssertException
+     */
+    public function find(string $activityId): array
+    {
+        GeneralHelpers::assert(
+            fn () => Assertion::minLength($activityId, 1, 'Activity id is required.')
+        );
+
+        return $this->httpLayer->get(
+            $this->buildUri("activities/$activityId")
+        );
+    }
 }

--- a/tests/Endpoints/ActivityTest.php
+++ b/tests/Endpoints/ActivityTest.php
@@ -75,6 +75,18 @@ class ActivityTest extends TestCase
         (new Activity($httpLayer, self::OPTIONS))->getAll($domainId, $activityParams);
     }
 
+    /**
+     * @throws MailerSendAssertException
+     * @throws \JsonException
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     */
+    public function test_find_requires_activity_id(): void
+    {
+        $this->expectException(MailerSendAssertException::class);
+
+        $this->activity->find('');
+    }
+
     public function validActivityParamsProvider(): array
     {
         return [


### PR DESCRIPTION
resolves #https://github.com/mailersend/mailersend/issues/5447

### Changelist
- [x] Add fetch single email activity
- [x] Test 