### PR TITLE
Implicit nullable types deprecated

### DIFF
--- a/src/Endpoints/SmtpUser.php
+++ b/src/Endpoints/SmtpUser.php
@@ -16,7 +16,7 @@ class SmtpUser extends AbstractEndpoint
      * @throws \JsonException
      * @throws \MailerSend\Exceptions\MailerSendAssertException
      */
-    public function getAll(string $domainId = null, ?int $limit = Constants::DEFAULT_LIMIT): array
+    public function getAll(?string $domainId = null, ?int $limit = Constants::DEFAULT_LIMIT): array
     {
         if ($limit) {
             GeneralHelpers::assert(

--- a/src/Helpers/Builder/Attachment.php
+++ b/src/Helpers/Builder/Attachment.php
@@ -12,10 +12,10 @@ class Attachment implements Arrayable, \JsonSerializable
     protected ?string $id = null;
 
     public function __construct(
-        string $content = null,
-        string $filename = null,
-        string $disposition = null,
-        string $id = null
+        ?string $content = null,
+        ?string $filename = null,
+        ?string $disposition = null,
+        ?string $id = null
     ) {
         if ($content) {
             $this->setContent($content);

--- a/src/Helpers/Builder/Filter.php
+++ b/src/Helpers/Builder/Filter.php
@@ -11,7 +11,7 @@ class Filter implements Arrayable, \JsonSerializable
     protected string $value;
     protected ?string $key;
 
-    public function __construct(string $comparer, string $value, string $key = null)
+    public function __construct(string $comparer, string $value, ?string $key = null)
     {
         $this->comparer = $comparer;
         $this->value = $value;

--- a/src/Helpers/Builder/SmsInbound.php
+++ b/src/Helpers/Builder/SmsInbound.php
@@ -9,10 +9,10 @@ class SmsInbound implements Arrayable, \JsonSerializable
     protected ?string $smsNumberId = null;
     protected ?string $name = null;
     protected ?string $forward_url = null;
-    protected $filter = null;
+    protected ?SmsInboundFilter $filter = null;
     protected ?bool $enabled = true;
 
-    public function __construct(string $smsNumberId = null, string $name = null, string $forward_url = null, $filter = null, bool $enabled = null)
+    public function __construct(?string $smsNumberId = null, ?string $name = null, ?string $forward_url = null, ?SmsInboundFilter $filter = null, ?bool $enabled = null)
     {
         $this->smsNumberId = $smsNumberId;
         $this->name = $name;

--- a/src/Helpers/Builder/SmsWebhookParams.php
+++ b/src/Helpers/Builder/SmsWebhookParams.php
@@ -34,7 +34,7 @@ class SmsWebhookParams implements Arrayable, \JsonSerializable
      * @param bool|null $enabled
      * @throws MailerSendAssertException
      */
-    public function __construct(string $url = null, string $name = null, array $events = null, string $smsNumberId = null, ?bool $enabled = null)
+    public function __construct(?string $url = null, ?string $name = null, ?array $events = null, ?string $smsNumberId = null, ?bool $enabled = null)
     {
         $this->setUrl($url)
             ->setName($name)

--- a/src/Helpers/Builder/UserParams.php
+++ b/src/Helpers/Builder/UserParams.php
@@ -17,7 +17,7 @@ class UserParams implements Arrayable, \JsonSerializable
      * @param string $email
      * @param string $role
      */
-    public function __construct(string $email = null, string $role = null)
+    public function __construct(?string $email = null, ?string $role = null)
     {
         $this->email = $email;
         $this->role = $role;


### PR DESCRIPTION
resolves [MSD-12576](https://linear.app/mailerlite/issue/MSD-12576/implicit-nullable-types-deprecated)

### Changelist

 - [x] Update null parameters to use explicit null types