### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-24.04]
-        php-versions: ['7.4','8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4','8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-24.04]
-                php-versions: ['7.4','8.0']
+                php-versions: ['7.4','8.0', '8.1', '8.2', '8.3', '8.4']
         name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
       "@php vendor/bin/phpunit tests/"
     ],
     "phpcs": [
-      "@php vendor/bin/php-cs-fixer fix --verbose --diff"
+      "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --verbose --diff"
     ]
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,12 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^7.4 || ^8.0 <8.4",
+    "php": "^7.4 || ^8.0 <8.5",
     "php-http/client-common": "^2.2",
     "php-http/discovery": "^1.9",
     "php-http/httplug": "^2.1",
     "psr/http-client-implementation": "^1.0",
     "psr/http-message": "^1.0 || ^2.0",
-    "illuminate/collections": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
     "beberlei/assert": "^3.2",
     "symfony/options-resolver": "^4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0 || ^7.0"
   },

--- a/src/Contracts/Arrayable.php
+++ b/src/Contracts/Arrayable.php
@@ -10,4 +10,4 @@ interface Arrayable
      * @return array
      */
     public function toArray();
-} 
+}

--- a/src/Contracts/Arrayable.php
+++ b/src/Contracts/Arrayable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MailerSend\Contracts;
+
+interface Arrayable
+{
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray();
+} 

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace MailerSend\Helpers;
+
+class Arr
+{
+    /**
+     * Get an item from an array using "dot" notation.
+     *
+     * @param array $array
+     * @param string|int|null $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public static function get($array, $key, $default = null)
+    {
+        if (is_null($key)) {
+            return $array;
+        }
+
+        if (isset($array[$key])) {
+            return $array[$key];
+        }
+
+        foreach (explode('.', $key) as $segment) {
+            if (!is_array($array) || !array_key_exists($segment, $array)) {
+                return $default;
+            }
+            $array = $array[$segment];
+        }
+
+        return $array;
+    }
+
+    /**
+     * Set an array item to a given value using "dot" notation.
+     *
+     * @param array $array
+     * @param string|int|null $key
+     * @param mixed $value
+     * @return array
+     */
+    public static function set(&$array, $key, $value)
+    {
+        if (is_null($key)) {
+            return $array = $value;
+        }
+
+        $keys = explode('.', $key);
+
+        foreach ($keys as $i => $key) {
+            if (count($keys) === 1) {
+                break;
+            }
+
+            unset($keys[$i]);
+
+            if (!isset($array[$key]) || !is_array($array[$key])) {
+                $array[$key] = [];
+            }
+
+            $array = &$array[$key];
+        }
+
+        $array[array_shift($keys)] = $value;
+
+        return $array;
+    }
+
+    /**
+     * Check if an item or items exist in an array using "dot" notation.
+     *
+     * @param array $array
+     * @param string|array $keys
+     * @return bool
+     */
+    public static function has($array, $keys)
+    {
+        $keys = (array) $keys;
+
+        if (empty($array) || $keys === []) {
+            return false;
+        }
+
+        foreach ($keys as $key) {
+            $subKeyArray = $array;
+
+            if (array_key_exists($key, $array)) {
+                continue;
+            }
+
+            foreach (explode('.', $key) as $segment) {
+                if (!is_array($subKeyArray) || !array_key_exists($segment, $subKeyArray)) {
+                    return false;
+                }
+                $subKeyArray = $subKeyArray[$segment];
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get all of the given array except for a specified array of keys.
+     *
+     * @param array $array
+     * @param array|string $keys
+     * @return array
+     */
+    public static function except($array, $keys)
+    {
+        return array_diff_key($array, array_flip((array) $keys));
+    }
+
+    /**
+     * Get a subset of the items from the given array.
+     *
+     * @param array $array
+     * @param array|string $keys
+     * @return array
+     */
+    public static function only($array, $keys)
+    {
+        return array_intersect_key($array, array_flip((array) $keys));
+    }
+
+    /**
+     * Filter the array using the given callback.
+     *
+     * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function where($array, callable $callback)
+    {
+        return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+    }
+} 

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -135,4 +135,4 @@ class Arr
     {
         return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
     }
-} 
+}

--- a/src/Helpers/Builder/Attachment.php
+++ b/src/Helpers/Builder/Attachment.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class Attachment implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/CatchFilter.php
+++ b/src/Helpers/Builder/CatchFilter.php
@@ -2,8 +2,8 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Arr;
+use MailerSend\Contracts\Arrayable;
+use MailerSend\Helpers\Arr;
 
 class CatchFilter implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/DomainParams.php
+++ b/src/Helpers/Builder/DomainParams.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class DomainParams implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/EmailVerificationParams.php
+++ b/src/Helpers/Builder/EmailVerificationParams.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class EmailVerificationParams implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/Filter.php
+++ b/src/Helpers/Builder/Filter.php
@@ -2,8 +2,8 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Arr;
+use MailerSend\Contracts\Arrayable;
+use MailerSend\Helpers\Arr;
 
 class Filter implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/Forward.php
+++ b/src/Helpers/Builder/Forward.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class Forward implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/Header.php
+++ b/src/Helpers/Builder/Header.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Helpers\Builder;
 
 use Assert\Assertion;
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\GeneralHelpers;
 

--- a/src/Helpers/Builder/Inbound.php
+++ b/src/Helpers/Builder/Inbound.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class Inbound implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/MatchFilter.php
+++ b/src/Helpers/Builder/MatchFilter.php
@@ -2,8 +2,8 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Arr;
+use MailerSend\Contracts\Arrayable;
+use MailerSend\Helpers\Arr;
 
 class MatchFilter implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/Personalization.php
+++ b/src/Helpers/Builder/Personalization.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Helpers\Builder;
 
 use Assert\Assertion;
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\GeneralHelpers;
 

--- a/src/Helpers/Builder/Recipient.php
+++ b/src/Helpers/Builder/Recipient.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Helpers\Builder;
 
 use Assert\Assertion;
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\GeneralHelpers;
 

--- a/src/Helpers/Builder/SenderIdentity.php
+++ b/src/Helpers/Builder/SenderIdentity.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class SenderIdentity implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/SmsInbound.php
+++ b/src/Helpers/Builder/SmsInbound.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class SmsInbound implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/SmsInboundFilter.php
+++ b/src/Helpers/Builder/SmsInboundFilter.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class SmsInboundFilter implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/SmsPersonalization.php
+++ b/src/Helpers/Builder/SmsPersonalization.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Helpers\Builder;
 
 use Assert\Assertion;
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\GeneralHelpers;
 

--- a/src/Helpers/Builder/SmsWebhookParams.php
+++ b/src/Helpers/Builder/SmsWebhookParams.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Helpers\Builder;
 
 use Assert\Assertion;
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\GeneralHelpers;
 

--- a/src/Helpers/Builder/SmtpUserParams.php
+++ b/src/Helpers/Builder/SmtpUserParams.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class SmtpUserParams implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/TokenParams.php
+++ b/src/Helpers/Builder/TokenParams.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Helpers\Builder;
 
 use Assert\Assertion;
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 use JsonSerializable;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\GeneralHelpers;

--- a/src/Helpers/Builder/UserParams.php
+++ b/src/Helpers/Builder/UserParams.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Helpers\Builder;
 
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 
 class UserParams implements Arrayable, \JsonSerializable
 {

--- a/src/Helpers/Builder/WebhookParams.php
+++ b/src/Helpers/Builder/WebhookParams.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Helpers\Builder;
 
 use Assert\Assertion;
-use Illuminate\Contracts\Support\Arrayable;
+use MailerSend\Contracts\Arrayable;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\GeneralHelpers;
 

--- a/src/Helpers/GeneralHelpers.php
+++ b/src/Helpers/GeneralHelpers.php
@@ -4,7 +4,6 @@ namespace MailerSend\Helpers;
 
 use Assert\Assertion;
 use Assert\AssertionFailedException;
-use Illuminate\Support\Collection;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\EmailParams;
 use MailerSend\Helpers\Builder\SmsParams;
@@ -87,9 +86,9 @@ class GeneralHelpers
 
     public static function mapToArray(array $data, string $object): array
     {
-        return (new Collection($data))->map(fn ($v) => is_object($v) && is_a(
-            $v,
-            $object
-        ) ? $v->toArray() : $v)->toArray();
+        return array_map(
+            fn ($v) => is_object($v) && is_a($v, $object) ? $v->toArray() : $v,
+            $data
+        );
     }
 }

--- a/src/MailerSend.php
+++ b/src/MailerSend.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend;
 
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Activity;
 use MailerSend\Endpoints\Analytics;

--- a/tests/Common/HttpLayerTest.php
+++ b/tests/Common/HttpLayerTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Common;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Endpoints/ActivityTest.php
+++ b/tests/Endpoints/ActivityTest.php
@@ -3,10 +3,10 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Activity;
 use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\Arr;
 use MailerSend\Helpers\Builder\ActivityParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Endpoints/AnalyticsTest.php
+++ b/tests/Endpoints/AnalyticsTest.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Tests\Endpoints;
 
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\OpensAnalyticsParams;

--- a/tests/Endpoints/BlocklistTest.php
+++ b/tests/Endpoints/BlocklistTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Blocklist;

--- a/tests/Endpoints/BulkEmailTest.php
+++ b/tests/Endpoints/BulkEmailTest.php
@@ -3,11 +3,11 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\BulkEmail;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Exceptions\MailerSendValidationException;
+use MailerSend\Helpers\Arr;
 use MailerSend\Helpers\Builder\Attachment;
 use MailerSend\Helpers\Builder\EmailParams;
 use MailerSend\Helpers\Builder\Personalization;

--- a/tests/Endpoints/DomainTest.php
+++ b/tests/Endpoints/DomainTest.php
@@ -3,7 +3,6 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Domain;
 use MailerSend\Exceptions\MailerSendAssertException;
@@ -11,6 +10,7 @@ use MailerSend\Helpers\Builder\DomainParams;
 use MailerSend\Helpers\Builder\DomainSettingsParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class DomainTest extends TestCase
 {

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -3,12 +3,12 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Email;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Exceptions\MailerSendRateLimitException;
 use MailerSend\Exceptions\MailerSendValidationException;
+use MailerSend\Helpers\Arr;
 use MailerSend\Helpers\Builder\Attachment;
 use MailerSend\Helpers\Builder\EmailParams;
 use MailerSend\Helpers\Builder\Personalization;

--- a/tests/Endpoints/EmailVerificationTest.php
+++ b/tests/Endpoints/EmailVerificationTest.php
@@ -3,13 +3,13 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\EmailVerification;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\EmailVerificationParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class EmailVerificationTest extends TestCase
 {

--- a/tests/Endpoints/HardBounceTest.php
+++ b/tests/Endpoints/HardBounceTest.php
@@ -3,7 +3,6 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\HardBounce;
@@ -11,6 +10,7 @@ use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\SuppressionParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class HardBounceTest extends TestCase
 {

--- a/tests/Endpoints/InboundTest.php
+++ b/tests/Endpoints/InboundTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Inbound;

--- a/tests/Endpoints/InviteTest.php
+++ b/tests/Endpoints/InviteTest.php
@@ -3,12 +3,12 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Common\Roles;
 use MailerSend\Endpoints\Invite;
 use MailerSend\Endpoints\User;
 use MailerSend\Exceptions\MailerSendAssertException;
+use MailerSend\Helpers\Arr;
 use MailerSend\Helpers\Builder\UserParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Endpoints/MessageTest.php
+++ b/tests/Endpoints/MessageTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Message;
 use MailerSend\Tests\TestCase;

--- a/tests/Endpoints/OnHoldListTest.php
+++ b/tests/Endpoints/OnHoldListTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\OnHoldList;

--- a/tests/Endpoints/PersonalizationTest.php
+++ b/tests/Endpoints/PersonalizationTest.php
@@ -1,1 +1,0 @@
-use MailerSend\Helpers\Arr; 

--- a/tests/Endpoints/PersonalizationTest.php
+++ b/tests/Endpoints/PersonalizationTest.php
@@ -1,0 +1,1 @@
+use MailerSend\Helpers\Arr; 

--- a/tests/Endpoints/RecipientTest.php
+++ b/tests/Endpoints/RecipientTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Recipient;
 use MailerSend\Tests\TestCase;

--- a/tests/Endpoints/ScheduleMessagesTest.php
+++ b/tests/Endpoints/ScheduleMessagesTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\ScheduleMessages;

--- a/tests/Endpoints/SenderIdentityTest.php
+++ b/tests/Endpoints/SenderIdentityTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SenderIdentity;
 use MailerSend\Exceptions\MailerSendAssertException;

--- a/tests/Endpoints/SmsActivityTest.php
+++ b/tests/Endpoints/SmsActivityTest.php
@@ -3,13 +3,13 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SmsActivity;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\SmsActivityParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class SmsActivityTest extends TestCase
 {

--- a/tests/Endpoints/SmsInboundTest.php
+++ b/tests/Endpoints/SmsInboundTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SmsInbound;
 use MailerSend\Exceptions\MailerSendAssertException;

--- a/tests/Endpoints/SmsMessageTest.php
+++ b/tests/Endpoints/SmsMessageTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SmsMessage;
 use MailerSend\Exceptions\MailerSendAssertException;

--- a/tests/Endpoints/SmsNumberTest.php
+++ b/tests/Endpoints/SmsNumberTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SmsNumber;
 use MailerSend\Exceptions\MailerSendAssertException;

--- a/tests/Endpoints/SmsPersonalizationTest.php
+++ b/tests/Endpoints/SmsPersonalizationTest.php
@@ -1,1 +1,0 @@
-use MailerSend\Helpers\Arr; 

--- a/tests/Endpoints/SmsPersonalizationTest.php
+++ b/tests/Endpoints/SmsPersonalizationTest.php
@@ -1,0 +1,1 @@
+use MailerSend\Helpers\Arr; 

--- a/tests/Endpoints/SmsRecipientTest.php
+++ b/tests/Endpoints/SmsRecipientTest.php
@@ -3,13 +3,13 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SmsRecipient;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\SmsRecipientParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class SmsRecipientTest extends TestCase
 {

--- a/tests/Endpoints/SmsTest.php
+++ b/tests/Endpoints/SmsTest.php
@@ -3,7 +3,6 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Sms;
 use MailerSend\Exceptions\MailerSendAssertException;
@@ -11,6 +10,7 @@ use MailerSend\Helpers\Builder\SmsParams;
 use MailerSend\Helpers\Builder\SmsPersonalization;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class SmsTest extends TestCase
 {

--- a/tests/Endpoints/SmsWebhookTest.php
+++ b/tests/Endpoints/SmsWebhookTest.php
@@ -3,12 +3,12 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SmsWebhook;
 use MailerSend\Helpers\Builder\SmsWebhookParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class SmsWebhookTest extends TestCase
 {

--- a/tests/Endpoints/SmtpUserTest.php
+++ b/tests/Endpoints/SmtpUserTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SmtpUser;
 use MailerSend\Exceptions\MailerSendAssertException;

--- a/tests/Endpoints/SpamComplaintTest.php
+++ b/tests/Endpoints/SpamComplaintTest.php
@@ -3,7 +3,6 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\SpamComplaint;
@@ -11,6 +10,7 @@ use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\SuppressionParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class SpamComplaintTest extends TestCase
 {

--- a/tests/Endpoints/TemplateTest.php
+++ b/tests/Endpoints/TemplateTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Template;
 use MailerSend\Exceptions\MailerSendAssertException;

--- a/tests/Endpoints/TokenTest.php
+++ b/tests/Endpoints/TokenTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Token;
 use MailerSend\Helpers\Builder\TokenParams;

--- a/tests/Endpoints/UnsubscribeTest.php
+++ b/tests/Endpoints/UnsubscribeTest.php
@@ -3,7 +3,7 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Common\Constants;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Unsubscribe;

--- a/tests/Endpoints/UserTest.php
+++ b/tests/Endpoints/UserTest.php
@@ -3,7 +3,6 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Common\Roles;
 use MailerSend\Endpoints\User;
@@ -11,6 +10,7 @@ use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\UserParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class UserTest extends TestCase
 {
@@ -122,7 +122,6 @@ class UserTest extends TestCase
 
     /**
      * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws MailerSendAssertException
      * @throws \JsonException
      */
     public function test_delete(): void

--- a/tests/Endpoints/WebhookTest.php
+++ b/tests/Endpoints/WebhookTest.php
@@ -3,12 +3,12 @@
 namespace MailerSend\Tests\Endpoints;
 
 use Http\Mock\Client;
-use Illuminate\Support\Arr;
 use MailerSend\Common\HttpLayer;
 use MailerSend\Endpoints\Webhook;
 use MailerSend\Helpers\Builder\WebhookParams;
 use MailerSend\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use MailerSend\Helpers\Arr;
 
 class WebhookTest extends TestCase
 {

--- a/tests/Helpers/Builder/AttachmentTest.php
+++ b/tests/Helpers/Builder/AttachmentTest.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Tests\Helpers\Builder;
 
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Helpers\Builder\Attachment;
 use MailerSend\Tests\TestCase;
 

--- a/tests/Helpers/Builder/HeaderTest.php
+++ b/tests/Helpers/Builder/HeaderTest.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Tests\Helpers\Builder;
 
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\Header;
 use MailerSend\Tests\TestCase;

--- a/tests/Helpers/Builder/PersonalizationTest.php
+++ b/tests/Helpers/Builder/PersonalizationTest.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Tests\Helpers\Builder;
 
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\Personalization;
 use MailerSend\Tests\TestCase;

--- a/tests/Helpers/Builder/RecipientTest.php
+++ b/tests/Helpers/Builder/RecipientTest.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Tests\Helpers\Builder;
 
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Exceptions\MailerSendAssertException;
 use MailerSend\Helpers\Builder\Recipient;
 use MailerSend\Tests\TestCase;

--- a/tests/MailerSendTest.php
+++ b/tests/MailerSendTest.php
@@ -2,7 +2,7 @@
 
 namespace MailerSend\Tests;
 
-use Illuminate\Support\Arr;
+use MailerSend\Helpers\Arr;
 use MailerSend\Endpoints\Email;
 use MailerSend\Exceptions\MailerSendException;
 use MailerSend\MailerSend;


### PR DESCRIPTION
resolves https://github.com/mailersend/mailersend-php/issues/159

##Summary
- Updated codebase to remove the `illuminate/collections` dependency.
- Replaced all usages of `Illuminate\Support\Arr` and `Illuminate\Contracts\Support\Arrayable` with custom implementations.
- Updated `composer.json` to ensure PHP CS Fixer works with PHP 8.4 by setting the `PHP_CS_FIXER_IGNORE_ENV` variable in the `phpcs` script.
- Ensured all tests and code style checks pass on PHP 8.4.