### PR TITLE
Allow Symfony 8 for options-resolver dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "psr/http-client-implementation": "^1.0",
     "psr/http-message": "^1.0 || ^2.0",
     "beberlei/assert": "^3.2",
-    "symfony/options-resolver": "^4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0 || ^7.0"
+    "symfony/options-resolver": "^4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5.15 || ^8.4 || ^9.0 || ^12.0",


### PR DESCRIPTION
## Summary
- Update `symfony/options-resolver` version constraint to include `^8.0`, allowing compatibility with Symfony 8

## Test plan
- [x] All 441 existing tests pass with 2528 assertions
- [x] Verify installation works with Symfony 8 options-resolver package

🤖 Generated with [Claude Code](https://claude.com/claude-code)