### PR TITLE
Add missing events to webhook params

### DIFF
--- a/src/Helpers/Builder/WebhookParams.php
+++ b/src/Helpers/Builder/WebhookParams.php
@@ -31,6 +31,11 @@ class WebhookParams implements Arrayable, \JsonSerializable
     public const ACTIVITY_MAINTENANCE_START = 'maintenance.start';
     public const ACTIVITY_MAINTENANCE_END = 'maintenance.end';
     public const ACTIVITY_INBOUND_FORWARD_FAILED = 'inbound_forward.failed';
+    public const ACTIVITY_EMAIL_SINGLE_VERIFIED = 'email_single.verified';
+    public const ACTIVITY_EMAIL_LIST_VERIFIED = 'email_list.verified';
+    public const ACTIVITY_BULK_EMAIL_COMPLETED = 'bulk_email.completed';
+    public const ACTIVITY_RECIPIENT_ON_HOLD_ADDED = 'recipient.on_hold_added';
+    public const ACTIVITY_RECIPIENT_ON_HOLD_REMOVED = 'recipient.on_hold_removed';
 
     public const ALL_ACTIVITIES = [
         self::ACTIVITY_SENT, self::ACTIVITY_DELIVERED,
@@ -41,6 +46,9 @@ class WebhookParams implements Arrayable, \JsonSerializable
         self::ACTIVITY_SURVEY_OPENED, self::ACTIVITY_SURVEY_SUBMITTED,
         self::ACTIVITY_IDENTITY_VERIFIED, self::ACTIVITY_MAINTENANCE_START,
         self::ACTIVITY_MAINTENANCE_END, self::ACTIVITY_INBOUND_FORWARD_FAILED,
+        self::ACTIVITY_EMAIL_SINGLE_VERIFIED, self::ACTIVITY_EMAIL_LIST_VERIFIED,
+        self::ACTIVITY_BULK_EMAIL_COMPLETED, self::ACTIVITY_RECIPIENT_ON_HOLD_ADDED,
+        self::ACTIVITY_RECIPIENT_ON_HOLD_REMOVED,
     ];
 
     /**

--- a/tests/Endpoints/WebhookTest.php
+++ b/tests/Endpoints/WebhookTest.php
@@ -309,4 +309,58 @@ class WebhookTest extends TestCase
         self::assertSame([WebhookParams::ACTIVITY_OPENED, WebhookParams::ACTIVITY_CLICKED], Arr::get($request_body, 'events'));
         self::assertEquals(false, Arr::get($request_body, 'enabled'));
     }
+
+    public function test_create_webhook_with_email_verification_events()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', [WebhookParams::ACTIVITY_EMAIL_SINGLE_VERIFIED, WebhookParams::ACTIVITY_EMAIL_LIST_VERIFIED], 'domain_id')
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals(200, $response['status_code']);
+        self::assertSame([WebhookParams::ACTIVITY_EMAIL_SINGLE_VERIFIED, WebhookParams::ACTIVITY_EMAIL_LIST_VERIFIED], Arr::get($request_body, 'events'));
+    }
+
+    public function test_create_webhook_with_bulk_email_completed_event()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', [WebhookParams::ACTIVITY_BULK_EMAIL_COMPLETED], 'domain_id')
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals(200, $response['status_code']);
+        self::assertSame([WebhookParams::ACTIVITY_BULK_EMAIL_COMPLETED], Arr::get($request_body, 'events'));
+    }
+
+    public function test_create_webhook_with_on_hold_events()
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $this->client->addResponse($response);
+
+        $response = $this->webhooks->create(
+            new WebhookParams('https://link.com/webhook', 'webhook name', [WebhookParams::ACTIVITY_RECIPIENT_ON_HOLD_ADDED, WebhookParams::ACTIVITY_RECIPIENT_ON_HOLD_REMOVED], 'domain_id')
+        );
+
+        $request = $this->client->getLastRequest();
+        $request_body = json_decode((string) $request->getBody(), true);
+
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals(200, $response['status_code']);
+        self::assertSame([WebhookParams::ACTIVITY_RECIPIENT_ON_HOLD_ADDED, WebhookParams::ACTIVITY_RECIPIENT_ON_HOLD_REMOVED], Arr::get($request_body, 'events'));
+    }
 }


### PR DESCRIPTION
resolves [MSD-10396](https://linear.app/mailerlite/issue/MSD-10396/on-hold-webhook)

### Changelist

- [ ] Add missing webhook events to WebhookParams