### PR TITLE
Add optional `language` field to email send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.39.0] - 2026 07 09
+
+### Added
+
+- Add optional language field to email send
+
 ## [0.37.0] - 2026 04 06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -329,6 +329,21 @@ $emailParams = (new EmailParams())
 $mailersend->email->send($emailParams);
 ```
 
+You can also send a template in a specific language using a language code (e.g. `de`, `fr`, `pt-BR`). When set, the template's published translation for that language is used, falling back to the base content if none exists. This is only meaningful when a `template_id` is set.
+
+```php
+$emailParams = (new EmailParams())
+    ->setFrom('your@domain.com')
+    ->setFromName('Your Name')
+    ->setRecipients($recipients)
+    ->setSubject('Subject')
+    ->setTemplateId('ss243wdasd')
+    ->setLanguage('de')
+    ->setTags($tags);
+
+$mailersend->email->send($emailParams);
+```
+
 <a name="personalization"></a>
 
 ### Personalization

--- a/src/Common/Constants.php
+++ b/src/Common/Constants.php
@@ -4,7 +4,7 @@ namespace MailerSend\Common;
 
 class Constants
 {
-    public const SDK_VERSION = 'v0.37.0';
+    public const SDK_VERSION = 'v0.39.0';
     public const DEFAULT_LIMIT = 25;
     public const MIN_LIMIT = 10;
     public const MAX_LIMIT = 100;

--- a/src/Endpoints/BulkEmail.php
+++ b/src/Endpoints/BulkEmail.php
@@ -48,6 +48,7 @@ class BulkEmail extends AbstractEndpoint
                     'bcc' => $bcc_mapped,
                     'subject' => $params->getSubject(),
                     'template_id' => $params->getTemplateId(),
+                    'language' => $params->getLanguage(),
                     'text' => $params->getText(),
                     'html' => $params->getHtml(),
                     'tags' => $params->getTags(),

--- a/src/Endpoints/Email.php
+++ b/src/Endpoints/Email.php
@@ -45,6 +45,7 @@ class Email extends AbstractEndpoint
                     'bcc' => $bcc_mapped,
                     'subject' => $params->getSubject(),
                     'template_id' => $params->getTemplateId(),
+                    'language' => $params->getLanguage(),
                     'text' => $params->getText(),
                     'html' => $params->getHtml(),
                     'tags' => $params->getTags(),

--- a/src/Helpers/Builder/EmailParams.php
+++ b/src/Helpers/Builder/EmailParams.php
@@ -15,6 +15,7 @@ class EmailParams
     protected ?string $html = null;
     protected ?string $text = null;
     protected ?string $template_id = null;
+    protected ?string $language = null;
     protected array $tags = [];
     protected array $attachments = [];
     protected array $personalization = [];
@@ -148,6 +149,17 @@ class EmailParams
     public function setTemplateId(?string $template_id): EmailParams
     {
         $this->template_id = $template_id;
+        return $this;
+    }
+
+    public function getLanguage(): ?string
+    {
+        return $this->language;
+    }
+
+    public function setLanguage(?string $language): EmailParams
+    {
+        $this->language = $language;
         return $this;
     }
 

--- a/tests/Endpoints/EmailTest.php
+++ b/tests/Endpoints/EmailTest.php
@@ -51,6 +51,52 @@ class EmailTest extends TestCase
         self::assertEquals([], $response);
     }
 
+    public function test_language_is_included_in_payload_when_set(): void
+    {
+        $recipients = [
+            new Recipient('recipient@mailersend.com', 'Recipient')
+        ];
+
+        $emailParams = (new EmailParams())
+            ->setRecipients($recipients)
+            ->setTemplateId('templateId')
+            ->setLanguage('de');
+
+        $httpLayer = $this->createStub(HttpLayer::class);
+        $httpLayer->method('post')
+            ->with('https://api.mailersend.com/v1/email', [
+                'to' => [
+                    $recipients[0]->toArray()
+                ],
+                'template_id' => 'templateId',
+                'language' => 'de',
+            ])
+            ->willReturn([]);
+
+        $response = (new Email($httpLayer, self::OPTIONS))->send($emailParams);
+
+        self::assertEquals([], $response);
+    }
+
+    public function test_language_is_absent_from_payload_when_not_set(): void
+    {
+        $recipients = [
+            new Recipient('recipient@mailersend.com', 'Recipient')
+        ];
+
+        $emailParams = (new EmailParams())
+            ->setRecipients($recipients)
+            ->setTemplateId('templateId');
+
+        $this->addSuccessResponse();
+
+        $this->email->send($emailParams);
+
+        $request_body = $this->assertRequest('POST', '/v1/email');
+
+        self::assertArrayNotHasKey('language', $request_body);
+    }
+
     /**
      * @dataProvider validEmailParamsProvider
      * @param EmailParams $emailParams


### PR DESCRIPTION
resolves [MSD-14489](https://linear.app/mailerlite/issue/MSD-14489/document-language-field-on-email-send-api-and-sdks)

Surfaces the new optional `language` field from the API's template-translations feature (MSD-14341) in the SDK.

### Changelist
- Add an optional `language` parameter to the email-send builder/params (e.g. `setLanguage("de")` / `.language("de")`), mirroring how `template_id` is handled.
- Include `language` in the request payload only when set; both single and bulk sends covered.
- README: add a short template + language example.